### PR TITLE
Added Simple9_RLE codec

### DIFF
--- a/headers/codecfactory.h
+++ b/headers/codecfactory.h
@@ -32,9 +32,7 @@
 #include "VarIntG8IU.h"
 #include "simdbinarypacking.h"
 #include "snappydelta.h"
-#if !defined(_MSC_VER) || (_MSC_VER != 1900)
 #include "varintgb.h"
-#endif
 
 namespace FastPForLib {
 

--- a/headers/codecfactory.h
+++ b/headers/codecfactory.h
@@ -14,6 +14,7 @@
 #include "util.h"
 #include "simple16.h"
 #include "simple9.h"
+#include "simple9_rle.h"
 #include "simple8b.h"
 #include "simple8b_rle.h"
 #include "newpfor.h"
@@ -31,7 +32,9 @@
 #include "VarIntG8IU.h"
 #include "simdbinarypacking.h"
 #include "snappydelta.h"
+#if !defined(_MSC_VER) || (_MSC_VER != 1900)
 #include "varintgb.h"
+#endif
 
 namespace FastPForLib {
 
@@ -121,10 +124,14 @@ static inline CodecMap initializefactory() {
             new CompositeCodec<SIMDOPTPFor<4, Simple16<false> > , VariableByte> ());
     map["varint"] = std::shared_ptr<IntegerCODEC> (new VariableByte());
     map["vbyte"] = std::shared_ptr<IntegerCODEC> (new VByte());
+#if !defined(_MSC_VER) || (_MSC_VER != 1900)
     map["varintgb"] = std::shared_ptr<IntegerCODEC> (new VarIntGB<>());
-
+#endif
+    map["simple16"] = std::shared_ptr<IntegerCODEC>(new Simple16<true>());
+    map["simple9"] = std::shared_ptr<IntegerCODEC>(new Simple9<true>());
+    map["simple9_rle"] = std::shared_ptr<IntegerCODEC>(new Simple9_RLE<true>());
     map["simple8b"] = std::shared_ptr<IntegerCODEC> (new Simple8b<true> ());
-    map["simple8b_rle"] = std::shared_ptr<IntegerCODEC> (new Simple8b_RLE<true> ());
+    map["simple8b_rle"] = std::shared_ptr<IntegerCODEC> (new Simple8b_RLE<true>());
 #ifdef VARINTG8IU_H__
     map["varintg8iu"] = std::shared_ptr<IntegerCODEC> (new VarIntG8IU ());
 #endif

--- a/headers/deltautil.h
+++ b/headers/deltautil.h
@@ -484,11 +484,9 @@ public:
                     std::cerr << " expected size of "<<datas[k].size()<<" got "<<recoveredsize << std::endl;
                     throw std::logic_error("arrays don't have same size: bug.");
                 }
-#if !defined(_MSC_VER) || (_MSC_VER != 1900)
-                if (!equal(datas[k].begin(), datas[k].end(), recov)) {
-                    throw std::logic_error("we have a bug");
-                }
-#else
+                //if (!equal(datas[k].begin(), datas[k].end(), recov)) {
+                //    throw std::logic_error("we have a bug");
+                //}
                 for (size_t i = 0; i < datas[k].size(); i++) {
                     if (datas[k][i] != recov[i]) {
                         std::cout << "difference at index " << i << ":" << std::endl;
@@ -497,7 +495,6 @@ public:
                         throw std::logic_error("we have a bug");
                     }
                 }
-#endif
             }
             if (!pp.separatetimes) {
                 timemscomp += timemsdelta;

--- a/headers/deltautil.h
+++ b/headers/deltautil.h
@@ -90,11 +90,12 @@ void summarize(std::vector<algostats> & v, std::string prefix = "#") {
         }
         std::cout << prefix << std::endl << prefix << std::endl;
     }
-    for(algostats a : v) {
+	std::cout << " codec:                                  enc/mis dec/mis bits/i enc(ms) dec(ms)" << std::endl;
+	for(algostats a : v) {
         double deltaTime = a.deltatime + a.inversedeltatime;
         double totTime = deltaTime + a.comptime + a.decomptime;
         if (totTime > 0 && a.input > 0) {
-            std::cout << " " << std::setprecision(4) << a.name(40);
+            std::cout << " " << std::setprecision(1) << std::fixed << a.name(40);
             double input = static_cast<double>(a.input);
             if (deltaTime > 0) {
                 std::cout << input / a.deltatime << " \t "
@@ -109,13 +110,12 @@ void summarize(std::vector<algostats> & v, std::string prefix = "#") {
                      << static_cast<size_t>(a.inversedeltatime / 1000)
                      << std::endl;
             } else {
-                std::cout << input / a.comptime << " \t "
-                     << input / a.decomptime << " \t "
-                     << static_cast<double>(a.output) * 32.0 / input << " \t\t"
-                     << "TotalTimes (ms):  "
-                     << static_cast<size_t>(a.comptime / 1000) << " \t "
-                     << static_cast<size_t>(a.decomptime / 1000)
-                     << std::endl;
+                std::cout << std::setw(7) << input / a.comptime << " "
+					 << std::setw(7) << input / a.decomptime << " "
+					 << std::setw(6) << a.output * 32.0 / input << " "
+					 << std::setw(7) << a.comptime / 1000 << " "
+					 << std::setw(7) << a.decomptime / 1000
+					 << std::endl;
             }
         }
     }
@@ -484,10 +484,20 @@ public:
                     std::cerr << " expected size of "<<datas[k].size()<<" got "<<recoveredsize << std::endl;
                     throw std::logic_error("arrays don't have same size: bug.");
                 }
-                if (!equal(datas[k].begin(),datas[k].end(), recov))  {
+#if !defined(_MSC_VER) || (_MSC_VER != 1900)
+                if (!equal(datas[k].begin(), datas[k].end(), recov)) {
                     throw std::logic_error("we have a bug");
                 }
-
+#else
+                for (size_t i = 0; i < datas[k].size(); i++) {
+                    if (datas[k][i] != recov[i]) {
+                        std::cout << "difference at index " << i << ":" << std::endl;
+                        std::cout << "  expected: " << datas[k][i] << std::endl;
+                        std::cout << "    actual: " << recov[i] << std::endl;
+                        throw std::logic_error("we have a bug");
+                    }
+                }
+#endif
             }
             if (!pp.separatetimes) {
                 timemscomp += timemsdelta;

--- a/headers/memutil.h
+++ b/headers/memutil.h
@@ -52,6 +52,9 @@ public:
     }
     AlignedSTLAllocator(const AlignedSTLAllocator& ) {
     }
+    template<typename U>
+    AlignedSTLAllocator(const AlignedSTLAllocator<U, alignment> &) {
+    }
     ~AlignedSTLAllocator() {
     }
 

--- a/headers/simple8b_rle.h
+++ b/headers/simple8b_rle.h
@@ -1,33 +1,25 @@
 /**
- * This code is released under the
- * Apache License Version 2.0 http://www.apache.org/licenses/.
- *
- * (c) Daniel Lemire, http://lemire.me/en/
- */
-
-#ifndef SIMPLE8B_RLE_H_
-#define SIMPLE8B_RLE_H_
-
-#include "common.h"
-#include "codecs.h"
-
-namespace FastPForLib {
-
-/**
-*  Simple8b
+*  This code is released under the
+*  Apache License Version 2.0 http://www.apache.org/licenses/.
+*
+*  Implemented by Daniel Lemire, http://lemire.me/en/
+*  (c) Daniel Lemire, http://lemire.me/en/
 *
 *  Follows Vo Ngoc Anh, Alistair Moffat: Index compression using 64-bit words.
 *  Softw., Pract. Exper. 40(2): 131-147 (2010)
-*
-*  Implemented by D. Lemire
-*
-*  RLE variant:
+**/
+
+/*****************************************************
+***** Simple8b-like encoder/decoder, RLE variant *****
+******************************************************
 *
 *  Instead of using selector values 0 and 1 for encoding 240 and 120 integers,
 *  a single selector value 15 is used to run-length encode up to 2^28 repeated
 *  32-bit integers. The rest of the selector values are shifted down by one to
 *  their natural position (selector values 1-14 will encode bit lengths 1-60).
-*  This also frees up selector value 0 to be used as end of stream marker.
+*
+*  This also frees up selector value 0, so 64-bit output value 0 can now be
+*  used as end-of-stream marker as it cannot be produced by the compressor.
 *
 *  Selector value: 0 |  1  2  3  4  5  6  7  8  9 10 11 12 13 14 | 15 (RLE)
 *  Integers coded: 0 | 60 30 20 15 12 10  8  7  6  5  4  3  2  1 | up to 2^28
@@ -35,17 +27,17 @@ namespace FastPForLib {
 *
 *  If larger than 32-bit integers need to be RL-encoded, the 60 bits allocated
 *  for selector value 15 can be shifted more towards storage and less towards
-*  quantity, i.e 2^12 48bit integers, or the other way, say 2^44 16bit integers.
+*  quantity, e.g. 2^12 48-bit integers, or the other way, e.g. 2^44 16-bit ints.
 *
 *  Performance:
 *
-*  Decoding is somewhat faster (20-30%) than Simple8b due to less branching.
-*  On highly repeatable datasets it may be *the* fastest decoder of all :)
-*  Encoding is slower than Simple8b due to no optimization. The extra pass
-*  for run-length encoding is not that expensive and not a big factor.
+*  Decoding is somewhat faster than Simple8b most probably due to less branching.
+*  Encoding is somewhat slower than Simple8b mostly due to no optimization at all.
+*  The extra check for run-length encoding is optional, cheap and not a big factor.
+*  Code is mostly unoptimized to keep it small, portable and facilitate easy reuse.
 *
 *  Since the encoding is entirely unoptimized to keep the code simple, there are
-*  some other bit packing schemes that have faster (2x) encoding, while costing
+*  some other bit packing schemes that can improve encoding speed, while costing
 *  only a minor increase in the packed size (packed bits per integer) metric.
 *  If your dataset does not have a lot of 1 bit integers, these may work better:
 *
@@ -59,218 +51,241 @@ namespace FastPForLib {
 *
 **/
 
-/**
-* If MarkLength is true, than the number of symbols is written
-* in the stream. Otherwise you need to specify it using the nvalue
-* parameter decodeArray.
-*
-* Note that when MarkLength is false, some unaligned (64-bit vs. 32-bit)
-* access are possible. This may fail on non-x86 platforms.
-*/
-	template<bool MarkLength>
-	class Simple8b_RLE : public IntegerCODEC {
+#ifndef SIMPLE8B_RLE_H_
+#define SIMPLE8B_RLE_H_
 
-	public:
-		void encodeArray(const uint32_t *in, const size_t length,
-			uint32_t *out, size_t &nvalue);
+#include "common.h"
+#include "codecs.h"
 
-		const uint32_t * decodeArray(const uint32_t *in, const size_t length,
-			uint32_t *out, size_t &nvalue);
+#define _SIMPLE8B_USE_RLE // optional, comment this line if run-length encoding is not needed
 
-		std::string name() const {
-			return "Simple8b_RLE";
-		}
+namespace FastPForLib {
 
-		Simple8b_RLE() { }
+    /**
+    * If MarkLength is true, than the number of symbols is written
+    * in the stream. Otherwise you need to specify it using the nvalue
+    * parameter decodeArray.
+    *
+    * Note that when MarkLength is false, some unaligned (64-bit vs. 32-bit)
+    * access are possible. This may fail on non-x86 platforms.
+    */
+    template<bool MarkLength>
+    class Simple8b_RLE : public IntegerCODEC {
 
-	private:
-		static const uint32_t SIMPLE8B_LOGDESC = 4;
-		static const uint32_t SIMPLE8B_BITS = (64 - SIMPLE8B_LOGDESC);
-		static const uint64_t RLE_MAX_VALUE = (1ULL << 32) - 1;
-		static const uint64_t RLE_MAX_COUNT = (1ULL << 28) - 1;
+    public:
+        std::string name() const {
+            return "Simple8b_RLE";
+        }
 
-		static const uint32_t bitLengths[];
+        void encodeArray(const uint32_t *in,
+            const size_t length, uint32_t *out, size_t &nvalue) {
 
-		static uint32_t ones(uint32_t x)
-		{
-			x -= ((x >> 1) & 0x55555555);
-			x = (((x >> 2) & 0x33333333) + (x & 0x33333333));
-			x = (((x >> 4) + x) & 0x0F0F0F0F);
-			x += (x >> 8);
-			x += (x >> 16);
-			return (x & 0x0000003F);
-		}
+            const uint32_t * const initout(out);
+            if (MarkLength) {
+                *out++ = static_cast<uint32_t>(length);
+            }
+            // this may lead to unaligned access. Performance may be affected.
+            // not much of an effect in practice on recent Intel processors.
+            uint64_t * out64 = reinterpret_cast<uint64_t*> (out);
+            auto count = Simple8b_Codec::Compress(in, 0, length, out64, 0);
+            nvalue = count * 2;
+        }
 
-		static uint32_t bits(uint32_t x)
-		{
-			x |= (x >> 1);
-			x |= (x >> 2);
-			x |= (x >> 4);
-			x |= (x >> 8);
-			x |= (x >> 16);
-			return ones(x);
-		}
+        const uint32_t * decodeArray(const uint32_t *in,
+            const size_t length, uint32_t *out, size_t &nvalue) {
 
-		// check if next integer repeats, return count if packs better, otherwize 0
-		static uint32_t tryRunLength(const uint32_t* input, uint32_t pos, uint32_t count)
-		{
-			uint32_t start = pos;
-			uint32_t end = (pos + count);
-			uint32_t test = input[pos++];
-			while (pos < end && test == input[pos]) { pos++; }
-			uint32_t bitLen = bits(test);
-			bitLen = (bitLen == 0) ? 1 : bitLen;
-			uint32_t repeatCount = (pos - start);
-			return (bitLen * repeatCount > SIMPLE8B_BITS) ? repeatCount : 0;
-		}
-
-		static bool tryBitPack(uint32_t bitLen, const uint32_t* input, uint32_t pos, uint32_t count)
-		{
-			if (bitLen >= 32)
-				return true;
-			uint32_t end = pos + count;
-			uint32_t maxval = 1U << (bitLen % 32);
-			uint32_t test = 0;
-			for (uint32_t i = pos; i < end; ++i) {
-				test |= input[i];
-			}
-			return test < maxval;
-		}
-	};
-
-	template<bool MarkLength>
-	const uint32_t Simple8b_RLE<MarkLength>::bitLengths[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 15, 20, 30, 60, 0 };
-	//const uint32_t Simple8b_RLE<MarkLength>::bitLengths[] = { 0, 2, 3, 4, 5, 6, 6, 7, 8, 9, 10, 12, 15, 20, 30, 0 };
-	//const uint32_t Simple8b_RLE<MarkLength>::bitLengths[] = { 0, 3, 4, 5, 5, 6, 6, 7, 8, 9, 10, 11, 12, 15, 20, 0 };
-	//const uint32_t Simple8b_RLE<MarkLength>::bitLengths[] = { 0, 4, 4, 5, 5, 6, 6, 7, 8, 9, 10, 11, 12, 14, 15, 0 };
-
-	template<bool MarkLength>
-	void Simple8b_RLE<MarkLength>::encodeArray(const uint32_t *input,
-		const size_t length, uint32_t *out, size_t &nvalue) {
-
-		const uint32_t * const initout(out);
-		if (MarkLength) {
-			*out++ = static_cast<uint32_t>(length);
-		}
-		// this may lead to unaligned access. Performance may be affected.
-		// not much of an effect in practice on recent Intel processors.
-		uint64_t * out64 = reinterpret_cast<uint64_t*> (out);
-
-		uint32_t pos = 0;
-		uint32_t count = static_cast<uint32_t>(length);
-
-		uint32_t remainingValuesCount = count;
-		while (remainingValuesCount > 0) {
-			uint64_t val = 0;
-
-			// try if run-length encoding packs better than bit packing
-			uint64_t numberOfRepeats = tryRunLength(input, pos, remainingValuesCount);
-			if (numberOfRepeats > 0) {
-				numberOfRepeats &= RLE_MAX_COUNT;
-				val = (15ULL << SIMPLE8B_BITS) | (numberOfRepeats << 32) | input[pos];
-				pos += static_cast<uint32_t>(numberOfRepeats);
-				remainingValuesCount -= static_cast<uint32_t>(numberOfRepeats);
-			}
-			// otherwise try all the bit packing possibilities
-			else {
-				uint32_t i;
-				for (i = 1; i < 15; ++i) {
-					uint32_t bitLen = bitLengths[i];
-					uint32_t codeNum = bitLengths[15 - i];
-					uint32_t numberOfValuesToPack = (remainingValuesCount < codeNum) ? remainingValuesCount : codeNum;
-
-					if (tryBitPack(bitLen, input, pos, numberOfValuesToPack)) {
-						val = i;
-						for (uint32_t j = 0; j < numberOfValuesToPack; j++) {
-							val = (val << bitLen) | input[pos + j];
-						}
-						val <<= SIMPLE8B_BITS - bitLen * numberOfValuesToPack;
-						pos += numberOfValuesToPack;
-						remainingValuesCount -= numberOfValuesToPack;
-						break;
-					}
-				}
-				// if no bit packing possible, encode just one value
-				if (i >= 15) {
-					val = (15ULL << SIMPLE8B_BITS) | (1ULL << 32) | input[pos];
-					pos += 1;
-					remainingValuesCount -= 1;
-				}
-			}
-			*out64++ = val;
-		}
-
-		assert(pos == length);
-		nvalue = reinterpret_cast<uint32_t*> (out64)-initout;
-	}
-
-	template<bool MarkLength>
-	const uint32_t * Simple8b_RLE<MarkLength>::decodeArray(const uint32_t *in,
-		const size_t length, uint32_t *out, size_t &nvalue) {
-
-		uint32_t markednvalue;
-		if (MarkLength) {
-			markednvalue = *in++;
-			if (markednvalue > nvalue)
-				throw NotEnoughStorage(markednvalue);
-		}
-		const size_t actualvalue = MarkLength ? markednvalue : nvalue;
-		// this may lead to unaligned access. Performance may be affected.
-		// not much of an effect in practice on recent Intel processors.
-		const uint64_t * in64 = reinterpret_cast<const uint64_t *> (in);
+            uint32_t markednvalue;
+            if (MarkLength) {
+                markednvalue = *in++;
+                if (markednvalue > nvalue)
+                    throw NotEnoughStorage(markednvalue);
+            }
+            const size_t actualvalue = MarkLength ? markednvalue : nvalue;
+            // this may lead to unaligned access. Performance may be affected.
+            // not much of an effect in practice on recent Intel processors.
+            const uint64_t * in64 = reinterpret_cast<const uint64_t *> (in);
 #ifndef NDEBUG
-		const uint32_t * const endin(in + length);
-		const uint64_t * finalin64 = reinterpret_cast<const uint64_t *> (endin);
+            const uint32_t * const endin(in + length);
+            const uint64_t * finalin64 = reinterpret_cast<const uint64_t *> (endin);
 #endif
-		if (nvalue < actualvalue)
-			std::cerr << " possible overrun" << std::endl;
-		nvalue = actualvalue;
-		const uint32_t * const end = out + nvalue;
-		const uint32_t * const initout(out);
+            if (nvalue < actualvalue) {
+                std::cerr << " possible overrun" << std::endl;
+            }
+            nvalue = actualvalue;
 
-		uint32_t pos = 0;
-		uint32_t count = static_cast<uint32_t>(length) / 2;
+            uint32_t pos = 0;
+            uint32_t count = static_cast<uint32_t>(length) / 2;
 
-		while (pos < count && end > out) {
-			uint64_t val = in64[pos++];
-			uint32_t code = static_cast<uint32_t>(val >> SIMPLE8B_BITS);
+            pos = Simple8b_Codec::Decompress(in64, 0, out, 0, nvalue);
 
-			if (code == 0) {
-				break; // end of stream
-			}
-			else if (code == 15) {
-				uint32_t repeatValue = static_cast<uint32_t>(val & RLE_MAX_VALUE);
-				uint32_t repeatCount = static_cast<uint32_t>((val >> 32) & RLE_MAX_COUNT);
-				for (uint32_t k = 0; k < repeatCount; ++k) {
-					*out++ = repeatValue;
-				}
-			}
-			else {
-				uint32_t bitLen = bitLengths[code];
-				uint32_t intNum = bitLengths[15 - code];
-				uint64_t mask = (1ULL << bitLen) - 1;
+            assert(in64 + pos <= finalin64);
+            in = reinterpret_cast<const uint32_t *> (in64 + pos);
+            assert(in <= endin);
+            nvalue = MarkLength ? actualvalue : nvalue;
+            return in;
+        }
+    };
 
-				uint32_t k = SIMPLE8B_BITS;
-				uint32_t last = SIMPLE8B_BITS - bitLen * (intNum - 3);
-				while (k > last) {
-					*out++ = static_cast<uint32_t>((val >> (k -= bitLen)) & mask);
-					*out++ = static_cast<uint32_t>((val >> (k -= bitLen)) & mask);
-					*out++ = static_cast<uint32_t>((val >> (k -= bitLen)) & mask);
-					*out++ = static_cast<uint32_t>((val >> (k -= bitLen)) & mask);
-				}
-				last = SIMPLE8B_BITS - bitLen * intNum;
-				while (k > last) {
-					*out++ = static_cast<uint32_t>((val >> (k -= bitLen)) & mask);
-				}
-			}
-		}
 
-		assert(in64 + pos <= finalin64);
-		in = reinterpret_cast<const uint32_t *> (in64 + pos);
-		assert(in <= endin);
-		nvalue = MarkLength ? actualvalue : out - initout;
-		return in;
-	}
+    /****************************************
+    ********** Simple8b-like codec **********
+    *****************************************/
+    class Simple8b_Codec {
+        static const uint32_t bitLength[];
+
+        static const uint32_t SIMPLE8B_BITSIZE = 60;
+        static const uint32_t SIMPLE8B_MAXCODE = 15;
+        static const uint32_t SIMPLE8B_MINCODE = 1;
+
+#if defined(_SIMPLE8B_USE_RLE)
+        static const uint32_t RLE_MAX_VALUE_BITS = 32;
+        static const uint32_t RLE_MAX_COUNT_BITS = SIMPLE8B_BITSIZE - RLE_MAX_VALUE_BITS;
+        static const uint64_t RLE_MAX_VALUE_MASK = (1ULL << RLE_MAX_VALUE_BITS) - 1;
+        static const uint64_t RLE_MAX_COUNT_MASK = (1ULL << RLE_MAX_COUNT_BITS) - 1;
+
+        static uint32_t bits(uint32_t i) {
+            i = i - ((i >> 1) & 0x55555555);
+            i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
+            return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
+        }
+
+        // check if next integer repeats, return count if packs better, otherwize 0
+        static uint32_t tryRunLength(const uint32_t* input, uint32_t pos, uint32_t count) {
+            uint32_t startPos = pos;
+            uint32_t endPos = pos + count;
+            uint32_t test = input[pos++];
+            if (test > RLE_MAX_VALUE_MASK)
+                return 0;
+            while (pos < endPos && test == input[pos]) { pos++; }
+            uint32_t bitLen = bits(test | 1U);
+            uint32_t repeatCount = (pos - startPos);
+            return (bitLen * repeatCount >= SIMPLE8B_BITSIZE) ? repeatCount : 0;
+        }
+#endif
+
+    public:
+        static int32_t Compress(const uint32_t * input, int32_t inOffset, uint32_t inCount, uint64_t * output, int32_t outOffset) {
+            uint32_t inPos = inOffset;
+            uint32_t inEnd = inOffset + inCount;
+            uint32_t outPos = outOffset;
+
+            while (inPos < inEnd) {
+                uint32_t remainingCount = inEnd - inPos;
+                uint64_t outVal = 0;
+
+#if defined(_SIMPLE8B_USE_RLE)
+                // try if run-length encoding packs better than bit packing
+                uint64_t repeatCount = tryRunLength(input, inPos, remainingCount);
+                if (repeatCount > 0) {
+                    repeatCount = (repeatCount < RLE_MAX_COUNT_MASK) ? repeatCount : RLE_MAX_COUNT_MASK;
+                    outVal = (static_cast<uint64_t>(SIMPLE8B_MAXCODE) << SIMPLE8B_BITSIZE) | (repeatCount << RLE_MAX_VALUE_BITS) | input[inPos];
+                    inPos += static_cast<uint32_t>(repeatCount);
+                }
+                else
+#endif
+                {
+                    // otherwise try all the bit packing possibilities
+                    uint32_t code = SIMPLE8B_MINCODE;
+                    for (; code < SIMPLE8B_MAXCODE; code++) {
+                        uint32_t intNum = bitLength[SIMPLE8B_MAXCODE - code];
+                        uint32_t bitLen = bitLength[code];
+                        intNum = (intNum < remainingCount) ? intNum : remainingCount;
+
+                        uint64_t maxVal = (1ULL << bitLen) - 1;
+                        uint64_t val = static_cast<uint64_t>(code) << SIMPLE8B_BITSIZE;
+                        uint32_t j = 0;
+                        for (; j < intNum; j++) {
+                            uint64_t inputVal = static_cast<uint64_t>(input[inPos + j]);
+                            if (inputVal > maxVal) { break; }
+                            val |= inputVal << (j * bitLen);
+                        }
+                        if (j == intNum) {
+                            outVal = val;
+                            inPos += intNum;
+                            break;
+                        }
+                    }
+                    // if no bit packing possible, encode just one value
+                    if (code == SIMPLE8B_MAXCODE) {
+                        outVal = (static_cast<uint64_t>(code) << SIMPLE8B_BITSIZE) | input[inPos++];
+                    }
+                }
+                output[outPos++] = outVal;
+            }
+            return outPos - outOffset;
+        }
+
+        static uint32_t Decompress(const uint64_t * input, uint32_t inOffset, uint32_t * output, uint32_t outOffset, uint32_t outCount) {
+            uint32_t inPos = 0;
+            uint32_t outPos = outOffset;
+            uint32_t outEnd = outOffset + outCount;
+
+            while (outPos < outEnd) {
+                uint32_t remainingCount = outEnd - outPos;
+
+                uint64_t val = input[inPos++];
+                uint32_t code = static_cast<uint32_t>(val >> SIMPLE8B_BITSIZE);
+
+                // optional check for end-of-stream
+                if (code == 0) {
+                    break; // end of stream
+                }
+
+#if defined(_SIMPLE8B_USE_RLE)
+                else if (code == SIMPLE8B_MAXCODE) {
+                    // decode rle-encoded integers
+                    uint32_t repeatValue = static_cast<uint32_t>(val & RLE_MAX_VALUE_MASK);
+                    uint32_t repeatCount = static_cast<uint32_t>((val >> RLE_MAX_VALUE_BITS) & RLE_MAX_COUNT_MASK);
+                    repeatCount = (repeatCount < remainingCount) ? repeatCount : remainingCount;
+
+                    for (uint32_t i = 0; i < repeatCount; ++i) {
+                        output[outPos++] = repeatValue;
+                    }
+                }
+#endif
+                else {
+                    // decode bit-packed integers
+                    uint32_t intNum = bitLength[SIMPLE8B_MAXCODE - code];
+                    uint32_t bitLen = bitLength[code];
+                    uint64_t bitMask = (1ULL << bitLen) - 1;
+                    intNum = (intNum < remainingCount) ? intNum : remainingCount; //optional buffer end check
+
+#if defined(_DONT_UNROLL_LOOP)
+                    for (uint32_t i = 0; i < intNum; ++i) {
+                        output[outPos++] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                    }
+#else
+                    uint32_t i = 0;
+                    for (; i < intNum; i += 8) {
+                        auto out = output + outPos + i;
+                        out[0] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                        out[1] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                        out[2] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                        out[3] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                        out[4] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                        out[5] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                        out[6] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                        out[7] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                    }
+                    for (; i < intNum; ++i) {
+                        auto out = output + outPos + i;
+                        out[0] = static_cast<uint32_t>(val & bitMask); val >>= bitLen;
+                    }
+                    outPos += intNum;
+#endif
+                }
+            }
+            return inPos;
+        }
+
+    };
+
+    const uint32_t Simple8b_Codec::bitLength[] = { 1, 1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 15, 20, 30, 60, 32 };
+    //const uint32_t Simple8b_Codec::bitLength[] = { 1, 2, 3, 4, 5, 6, 6, 7, 8, 9, 10, 12, 15, 20, 30, 32 };
+    //const uint32_t Simple8b_Codec::bitLength[] = { 1, 3, 4, 5, 5, 6, 6, 7, 8, 9, 10, 11, 12, 15, 20, 32 };
+    //const uint32_t Simple8b_Codec::bitLength[] = { 1, 4, 4, 5, 5, 6, 6, 7, 8, 9, 10, 11, 12, 14, 15, 32 };
+
+#undef _SIMPLE8B_USE_RLE
 
 } // namespace FastPFor
 

--- a/headers/simple9_rle.h
+++ b/headers/simple9_rle.h
@@ -1,0 +1,269 @@
+/**
+*  This code is released under the
+*  Apache License Version 2.0 http://www.apache.org/licenses/.
+*
+*  Implemented by Daniel Lemire, http://lemire.me/en/
+*
+*  Based on code by
+*      Takeshi Yamamuro <linguin.m.s_at_gmail.com>
+*      Fabrizio Silvestri <fabrizio.silvestri_at_isti.cnr.it>
+*      Rossano Venturini <rossano.venturini_at_isti.cnr.it>
+*  which was available under the Apache License, Version 2.0.
+*/
+
+/****************************************************
+***** Simple9-like encoder/decoder, RLE variant *****
+*****************************************************
+*
+*  Improves upon Simple9 by being able to encode up to 31-bit non-negative integers
+*  (instead of only 28-bit integers with Simple9), optionally can run-length encode
+*  up to 2^12 16-bit repeated integers, while retaining comparable speed to Simple9.
+*
+*  Possible targets may include 32-bit or branch-constrained environments like GPUs.
+*  The main goal is to have a small, simple and portable 32-bit integer compressor.
+*
+*  Selector values 1-7 encode betweeen 2 and 14 packed integers. Selector value 0 is
+*  used to either encode 28 packed 1-bit integers, optionally mark the end-of-stream,
+*  or run-length encode up to 2^12 repeated 16-bit integers (whichever packs better).
+*  Selector values 8-15 (i.e. the most significant bit set) encode one 31-bit integer.
+*  If input value is bigger than 31 bits, only the first 31 bits will be retained.
+*
+*  Selector value: | 0 (RLE) |  0 |  1  2  3  4  5  6  7 | 8 to 15 |
+*  Integers coded: | 1..2^12 | 28 | 14  9  7  5  4  3  2 | 1       |
+*  Bits / integer: | 16 bits |  1 |  2  3  4  5  7  9 14 | 31 bits |
+*
+*  If larger than 16-bit integers need to be RL-encoded, the 28 bits allocated for
+*  selector value 0 (RLE) can be shifted more towards integer size and less towards
+*  integer quantity, for example encoding up to 2^8 20-bit repeated integers.
+*
+*  Optionally, if run-length encoding and 28x1-bit integer packing are not needed,
+*  then selector code 0 can be left unused. This way 32-bit output value 0 cannot be
+*  produced by the compressor and so it can be used as end-of-stream marker instead.
+*
+*  Performance:
+*
+*  Decoding is somewhat faster than Simple9 most probably due to less branching.
+*  Encoding is somewhat slower than Simple9 mostly due to no optimizations at all.
+*  The extra check for run-length encoding is optional, cheap and not a big factor.
+*  Code is mostly unoptimized to keep it small, portable and facilitate easy reuse.
+*
+**/
+
+#ifndef SIMPLE9_RLE_H_
+#define SIMPLE9_RLE_H_
+
+#include "common.h"
+#include "codecs.h"
+
+//#define _SIMPLE9_USE_RLE // uncomment this line if run-length encoding is needed
+
+namespace FastPForLib {
+
+    /**
+    * If MarkLength is true, than the number of symbols is written
+    * in the stream. Otherwise you need to specify it using the nvalue
+    * parameter decodeArray.
+    */
+    template<bool MarkLength>
+    class Simple9_RLE : public IntegerCODEC {
+
+    public:
+        std::string name() const {
+            return "Simple9_RLE";
+        }
+
+        void encodeArray(const uint32_t *input, const size_t length, uint32_t *out, size_t &nvalue) {
+            auto len = length > 0 ? length : nvalue;
+            if (MarkLength) { *out++ = static_cast<uint32_t>(len); }
+            auto count = Simple9_Codec::Compress(input, 0, len, out, 0);
+            nvalue = count;
+        }
+
+        const uint32_t * decodeArray(const uint32_t *input, const size_t length, uint32_t *out, size_t &nvalue) {
+            uint32_t markednvalue;
+            if (MarkLength) {
+                markednvalue = *input++;
+                if (markednvalue > nvalue)
+                    throw NotEnoughStorage(markednvalue);
+            }
+            const size_t actualvalue = MarkLength ? markednvalue : nvalue;
+            if (nvalue < actualvalue) {
+                std::cerr << " possible overrun" << std::endl;
+            }
+            auto count = actualvalue;
+            Simple9_Codec::Decompress(input, 0, out, 0, count);
+            nvalue = MarkLength ? actualvalue : count;
+            input += count;
+            return input;
+        }
+    };
+
+
+    /***************************************
+    ********** Simple9-like codec **********
+    ****************************************/
+    class Simple9_Codec {
+
+        static const uint32_t intNumber[];
+        static const uint32_t bitLength[];
+
+        static const uint32_t SIMPLE9_BITSIZE = 28;
+        static const uint32_t SIMPLE9_MAXCODE = 8;
+
+#if !defined(_SIMPLE9_USE_RLE)
+        static const uint32_t SIMPLE9_MINCODE = 0; // set to 1 to use zero as end-of-stream marker.
+#else
+        static const uint32_t SIMPLE9_MINCODE = 1;
+
+        static const uint32_t RLE_SELECTOR_VALUE = 0;
+        static const uint32_t RLE_MAX_VALUE_BITS = 16;
+        static const uint32_t RLE_MAX_COUNT_BITS = SIMPLE9_BITSIZE - RLE_MAX_VALUE_BITS;
+        static const uint32_t RLE_MAX_VALUE_MASK = (1U << RLE_MAX_VALUE_BITS) - 1;
+        static const uint32_t RLE_MAX_COUNT_MASK = (1U << RLE_MAX_COUNT_BITS) - 1;
+
+        static uint32_t bits(uint32_t i) {
+            i = i - ((i >> 1) & 0x55555555);
+            i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
+            return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
+        }
+
+        // check if next integer repeats, return count if packs better, otherwize 0
+        static uint32_t tryRunLength(const uint32_t* input, uint32_t pos, uint32_t count) {
+            uint32_t startPos = pos;
+            uint32_t endPos = pos + count;
+            uint32_t test = input[pos++];
+            if (test > RLE_MAX_VALUE_MASK)
+                return 0;
+            while (pos < endPos && test == input[pos]) { pos++; }
+            uint32_t bitLen = bits(test | 1u);
+            uint32_t repeatCount = (pos - startPos);
+            return (bitLen * repeatCount >= SIMPLE9_BITSIZE) ? repeatCount : 0;
+        }
+#endif
+
+    public:
+        static int32_t Compress(const uint32_t * input, int32_t inOffset, uint32_t inCount, uint32_t * output, int32_t outOffset) {
+            uint32_t inPos = inOffset;
+            uint32_t inEnd = inOffset + inCount;
+            uint32_t outPos = outOffset;
+
+            while (inPos < inEnd) {
+                uint32_t remainingCount = inEnd - inPos;
+                uint32_t outVal = 0;
+
+#if defined(_SIMPLE9_USE_RLE)
+                // try if run-length encoding packs better than bit packing
+                uint32_t repeatCount = tryRunLength(input, inPos, remainingCount);
+                if (repeatCount > 0) {
+                    repeatCount = (repeatCount < RLE_MAX_COUNT_MASK) ? repeatCount : RLE_MAX_COUNT_MASK;
+                    outVal = (RLE_SELECTOR_VALUE << SIMPLE9_BITSIZE) | (repeatCount << RLE_MAX_VALUE_BITS) | input[inPos];
+                    inPos += repeatCount;
+                }
+                else
+#endif
+                {
+                    // try all the bit packing possibilities
+                    uint32_t code = SIMPLE9_MINCODE;
+                    for (; code < SIMPLE9_MAXCODE; code++) {
+                        uint32_t intNum = intNumber[code];
+                        uint32_t bitLen = bitLength[code];
+                        intNum = (intNum < remainingCount) ? intNum : remainingCount;
+
+                        uint32_t maxVal = (1U << bitLen) - 1;
+                        uint32_t val = code << SIMPLE9_BITSIZE;
+                        uint32_t j = 0;
+                        for (; j < intNum; j++) {
+                            uint32_t inputVal = input[inPos + j];
+                            if (inputVal > maxVal) { break; }
+                            val |= inputVal << (j * bitLen);
+                        }
+                        if (j == intNum) {
+                            outVal = val;
+                            inPos += intNum;
+                            break;
+                        }
+                    }
+                    // if no bit packing possible, encode just one value (up to INT_MAX)
+                    if (code == SIMPLE9_MAXCODE) {
+                        outVal = (code << SIMPLE9_BITSIZE) | input[inPos++];
+                    }
+                }
+                output[outPos++] = outVal;
+            }
+            return outPos - outOffset;
+        }
+
+        static uint32_t Decompress(const uint32_t * input, uint32_t inOffset, uint32_t * output, uint32_t outOffset, uint32_t outCount) {
+            uint32_t inPos = inOffset;
+            uint32_t outPos = outOffset;
+            uint32_t outEnd = outOffset + outCount;
+
+            while (outPos < outEnd) {
+                uint32_t remainingCount = outEnd - outPos;
+
+                uint32_t val = input[inPos++];
+                uint32_t code = val >> SIMPLE9_BITSIZE;
+
+#if defined(_SIMPLE9_USE_RLE)
+                if (code == RLE_SELECTOR_VALUE) {
+                    // decode rle-encoded integers
+                    uint32_t repeatValue = val & RLE_MAX_VALUE_MASK;
+                    uint32_t repeatCount = (val >> RLE_MAX_VALUE_BITS) & RLE_MAX_COUNT_MASK;
+                    repeatCount = (repeatCount < remainingCount) ? repeatCount : remainingCount;
+
+                    for (uint32_t i = 0; i < repeatCount; ++i) {
+                        output[outPos++] = repeatValue;
+                    }
+                }
+#else
+                // optional check for end-of-stream
+                if (SIMPLE9_MINCODE == 1 && code == 0) {
+                    break; // end of stream
+                }
+#endif				
+                else {
+                    // decode bit-packed integers
+                    uint32_t intNum = intNumber[code];
+                    uint32_t bitLen = bitLength[code];
+                    uint32_t bitMask = (1U << bitLen) - 1;
+                    intNum = (intNum < remainingCount) ? intNum : remainingCount; //optional buffer end check
+
+#if defined(_DONT_UNROLL_LOOP)
+                    for (uint32_t i = 0; i < intNum; ++i) {
+                        output[outPos++] = val & bitMask; val >>= bitLen;
+                    }
+#else
+                    uint32_t i = 0;
+                    for (; i < intNum; i += 7) {
+                        auto out = output + outPos + i;
+                        out[0] = val & bitMask; val >>= bitLen;
+                        out[1] = val & bitMask; val >>= bitLen;
+                        out[2] = val & bitMask; val >>= bitLen;
+                        out[3] = val & bitMask; val >>= bitLen;
+                        out[4] = val & bitMask; val >>= bitLen;
+                        out[5] = val & bitMask; val >>= bitLen;
+                        out[6] = val & bitMask; val >>= bitLen;
+                    }
+                    for (; i < intNum; ++i) {
+                        auto out = output + outPos + i;
+                        out[0] = val & bitMask; val >>= bitLen;
+                    }
+                    outPos += intNum;
+#endif
+                }
+            }
+            return inPos;
+        }
+
+    };
+
+    // --------------------------- selector code:  0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  A,  B,  C,  D,  E,  F
+    const uint32_t Simple9_Codec::intNumber[] = { 28, 14,  9,  7,  5,  4,  3,  2,  1,  1,  1,  1,  1,  1,  1,  1 };
+    const uint32_t Simple9_Codec::bitLength[] = { 1,   2,  3,  4,  5,  7,  9, 14, 31, 31, 31, 31, 31, 31, 31, 31 };
+
+#undef _SIMPLE9_USE_RLE
+
+} // namespace FastPFor
+
+
+#endif /* SIMPLE9_RLE_H_ */

--- a/msvc/FastPFor.sln
+++ b/msvc/FastPFor.sln
@@ -1,0 +1,71 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "codecs", "codecs.vcxproj", "{6EA32961-5F77-49C0-AB3B-4CFC8BCF325F}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FastPFor", "FastPFor.vcxproj", "{42D8ABA4-FC4E-426C-A833-D64D06081F92}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "getopt", "getopt.vcxproj", "{D0D480B3-816E-4A04-8AE4-75210F8701E0}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "inmemorybenchmark", "inmemorybenchmark.vcxproj", "{635B18E0-2AD7-45A7-914E-831A6B711F89}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "unit", "unit.vcxproj", "{8B2ED3AF-F2E8-480B-BE7D-7B6E44DC4BFE}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "csv2maropu", "csv2maropu.vcxproj", "{0B3B4EEE-2BE4-45E0-B569-6E8EA6C20640}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "entropy", "entropy.vcxproj", "{4651272C-AF97-4366-9CC2-D3F2981950E1}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example", "example.vcxproj", "{AC339FA7-903E-4641-A942-1D08D872CE94}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "benchbitpacking", "benchbitpacking.vcxproj", "{2759C6D3-AEFD-488B-B0DE-2FBF38C59033}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "gapstats", "gapstats.vcxproj", "{E453A390-F839-481E-BAD5-8491CB798E1E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6EA32961-5F77-49C0-AB3B-4CFC8BCF325F}.Debug|x64.ActiveCfg = Debug|x64
+		{6EA32961-5F77-49C0-AB3B-4CFC8BCF325F}.Debug|x64.Build.0 = Debug|x64
+		{6EA32961-5F77-49C0-AB3B-4CFC8BCF325F}.Release|x64.ActiveCfg = Release|x64
+		{6EA32961-5F77-49C0-AB3B-4CFC8BCF325F}.Release|x64.Build.0 = Release|x64
+		{42D8ABA4-FC4E-426C-A833-D64D06081F92}.Debug|x64.ActiveCfg = Debug|x64
+		{42D8ABA4-FC4E-426C-A833-D64D06081F92}.Debug|x64.Build.0 = Debug|x64
+		{42D8ABA4-FC4E-426C-A833-D64D06081F92}.Release|x64.ActiveCfg = Release|x64
+		{42D8ABA4-FC4E-426C-A833-D64D06081F92}.Release|x64.Build.0 = Release|x64
+		{D0D480B3-816E-4A04-8AE4-75210F8701E0}.Debug|x64.ActiveCfg = Debug|x64
+		{D0D480B3-816E-4A04-8AE4-75210F8701E0}.Debug|x64.Build.0 = Debug|x64
+		{D0D480B3-816E-4A04-8AE4-75210F8701E0}.Release|x64.ActiveCfg = Release|x64
+		{D0D480B3-816E-4A04-8AE4-75210F8701E0}.Release|x64.Build.0 = Release|x64
+		{635B18E0-2AD7-45A7-914E-831A6B711F89}.Debug|x64.ActiveCfg = Debug|x64
+		{635B18E0-2AD7-45A7-914E-831A6B711F89}.Debug|x64.Build.0 = Debug|x64
+		{635B18E0-2AD7-45A7-914E-831A6B711F89}.Release|x64.ActiveCfg = Release|x64
+		{635B18E0-2AD7-45A7-914E-831A6B711F89}.Release|x64.Build.0 = Release|x64
+		{8B2ED3AF-F2E8-480B-BE7D-7B6E44DC4BFE}.Debug|x64.ActiveCfg = Debug|x64
+		{8B2ED3AF-F2E8-480B-BE7D-7B6E44DC4BFE}.Debug|x64.Build.0 = Debug|x64
+		{8B2ED3AF-F2E8-480B-BE7D-7B6E44DC4BFE}.Release|x64.ActiveCfg = Release|x64
+		{8B2ED3AF-F2E8-480B-BE7D-7B6E44DC4BFE}.Release|x64.Build.0 = Release|x64
+		{0B3B4EEE-2BE4-45E0-B569-6E8EA6C20640}.Debug|x64.ActiveCfg = Debug|x64
+		{0B3B4EEE-2BE4-45E0-B569-6E8EA6C20640}.Release|x64.ActiveCfg = Release|x64
+		{0B3B4EEE-2BE4-45E0-B569-6E8EA6C20640}.Release|x64.Build.0 = Release|x64
+		{4651272C-AF97-4366-9CC2-D3F2981950E1}.Debug|x64.ActiveCfg = Debug|x64
+		{4651272C-AF97-4366-9CC2-D3F2981950E1}.Release|x64.ActiveCfg = Release|x64
+		{4651272C-AF97-4366-9CC2-D3F2981950E1}.Release|x64.Build.0 = Release|x64
+		{AC339FA7-903E-4641-A942-1D08D872CE94}.Debug|x64.ActiveCfg = Debug|x64
+		{AC339FA7-903E-4641-A942-1D08D872CE94}.Release|x64.ActiveCfg = Release|x64
+		{AC339FA7-903E-4641-A942-1D08D872CE94}.Release|x64.Build.0 = Release|x64
+		{2759C6D3-AEFD-488B-B0DE-2FBF38C59033}.Debug|x64.ActiveCfg = Debug|x64
+		{2759C6D3-AEFD-488B-B0DE-2FBF38C59033}.Release|x64.ActiveCfg = Release|x64
+		{2759C6D3-AEFD-488B-B0DE-2FBF38C59033}.Release|x64.Build.0 = Release|x64
+		{E453A390-F839-481E-BAD5-8491CB798E1E}.Debug|x64.ActiveCfg = Debug|x64
+		{E453A390-F839-481E-BAD5-8491CB798E1E}.Release|x64.ActiveCfg = Release|x64
+		{E453A390-F839-481E-BAD5-8491CB798E1E}.Release|x64.Build.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/msvc/FastPFor.vcxproj
+++ b/msvc/FastPFor.vcxproj
@@ -1,0 +1,82 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{42D8ABA4-FC4E-426C-A833-D64D06081F92}</ProjectGuid>
+    <RootNamespace>FastPFor</RootNamespace>
+    <TargetPlatformVersion>8.1</TargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\bitpacking.cpp" />
+    <ClCompile Include="..\src\bitpackingaligned.cpp" />
+    <ClCompile Include="..\src\bitpackingunaligned.cpp" />
+    <ClCompile Include="..\src\horizontalbitpacking.cpp" />
+    <ClCompile Include="..\src\simdbitpacking.cpp" />
+    <ClCompile Include="..\src\simdunalignedbitpacking.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/benchbitpacking.vcxproj
+++ b/msvc/benchbitpacking.vcxproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{2759C6D3-AEFD-488B-B0DE-2FBF38C59033}</ProjectGuid>
+    <RootNamespace>benchbitpacking</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\benchbitpacking.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastPFor.vcxproj">
+      <Project>{42d8aba4-fc4e-426c-a833-d64d06081f92}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/codecs.vcxproj
+++ b/msvc/codecs.vcxproj
@@ -1,0 +1,86 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{6EA32961-5F77-49C0-AB3B-4CFC8BCF325F}</ProjectGuid>
+    <RootNamespace>codecs</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers;./getopt</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers;./getopt</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\codecs.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastPFor.vcxproj">
+      <Project>{42d8aba4-fc4e-426c-a833-d64d06081f92}</Project>
+    </ProjectReference>
+    <ProjectReference Include="getopt.vcxproj">
+      <Project>{d0d480b3-816e-4a04-8ae4-75210f8701e0}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/csv2maropu.vcxproj
+++ b/msvc/csv2maropu.vcxproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0B3B4EEE-2BE4-45E0-B569-6E8EA6C20640}</ProjectGuid>
+    <RootNamespace>csv2maropu</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\csv2maropu.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastPFor.vcxproj">
+      <Project>{42d8aba4-fc4e-426c-a833-d64d06081f92}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/entropy.vcxproj
+++ b/msvc/entropy.vcxproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{4651272C-AF97-4366-9CC2-D3F2981950E1}</ProjectGuid>
+    <RootNamespace>entropy</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\entropy.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastPFor.vcxproj">
+      <Project>{42d8aba4-fc4e-426c-a833-d64d06081f92}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/example.vcxproj
+++ b/msvc/example.vcxproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{AC339FA7-903E-4641-A942-1D08D872CE94}</ProjectGuid>
+    <RootNamespace>example</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\example.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastPFor.vcxproj">
+      <Project>{42d8aba4-fc4e-426c-a833-d64d06081f92}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/gapstats.vcxproj
+++ b/msvc/gapstats.vcxproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{E453A390-F839-481E-BAD5-8491CB798E1E}</ProjectGuid>
+    <RootNamespace>gapstats</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\gapstats.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastPFor.vcxproj">
+      <Project>{42d8aba4-fc4e-426c-a833-d64d06081f92}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/getopt.vcxproj
+++ b/msvc/getopt.vcxproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D0D480B3-816E-4A04-8AE4-75210F8701E0}</ProjectGuid>
+    <RootNamespace>getopt</RootNamespace>
+    <TargetPlatformVersion>8.1</TargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="getopt\getopt.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/getopt/getopt.c
+++ b/msvc/getopt/getopt.c
@@ -1,0 +1,972 @@
+/* Getopt for Microsoft C
+This code is a modification of the Free Software Foundation, Inc.
+Getopt library for parsing command line argument the purpose was
+to provide a Microsoft Visual C friendly derivative. This code
+provides functionality for both Unicode and Multibyte builds.
+
+Date: 02/03/2011 - Ludvik Jerabek - Initial Release
+Version: 1.0
+Comment: Supports getopt, getopt_long, and getopt_long_only
+and POSIXLY_CORRECT environment flag
+License: LGPL
+
+Revisions:
+
+02/03/2011 - Ludvik Jerabek - Initial Release
+02/20/2011 - Ludvik Jerabek - Fixed compiler warnings at Level 4
+07/05/2011 - Ludvik Jerabek - Added no_argument, required_argument, optional_argument defs
+08/03/2011 - Ludvik Jerabek - Fixed non-argument runtime bug which caused runtime exception
+08/09/2011 - Ludvik Jerabek - Added code to export functions for DLL and LIB
+02/15/2012 - Ludvik Jerabek - Fixed _GETOPT_THROW definition missing in implementation file
+08/01/2012 - Ludvik Jerabek - Created separate functions for char and wchar_t characters so single dll can do both unicode and ansi
+10/15/2012 - Ludvik Jerabek - Modified to match latest GNU features
+
+**DISCLAIMER**
+THIS MATERIAL IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING, BUT Not LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, OR NON-INFRINGEMENT. SOME JURISDICTIONS DO NOT ALLOW THE
+EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSION MAY NOT
+APPLY TO YOU. IN NO EVENT WILL I BE LIABLE TO ANY PARTY FOR ANY
+DIRECT, INDIRECT, SPECIAL OR OTHER CONSEQUENTIAL DAMAGES FOR ANY
+USE OF THIS MATERIAL INCLUDING, WITHOUT LIMITATION, ANY LOST
+PROFITS, BUSINESS INTERRUPTION, LOSS OF PROGRAMS OR OTHER DATA ON
+YOUR INFORMATION HANDLING SYSTEM OR OTHERWISE, EVEN If WE ARE
+EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+*/
+#define _CRT_SECURE_NO_WARNINGS
+#include <stdlib.h>
+#include <stdio.h>
+#include <malloc.h>
+#include "getopt.h"
+
+#ifdef __cplusplus
+	#define _GETOPT_THROW throw()
+#else
+	#define _GETOPT_THROW
+#endif
+
+int optind = 1;
+int opterr = 1;
+int optopt = '?';
+enum ENUM_ORDERING { REQUIRE_ORDER, PERMUTE, RETURN_IN_ORDER };
+
+//
+//
+//		Ansi structures and functions follow
+// 
+//
+
+static struct _getopt_data_a
+{
+	int optind;
+	int opterr;
+	int optopt;
+	char *optarg;
+	int __initialized;
+	char *__nextchar;
+	enum ENUM_ORDERING __ordering;
+	int __posixly_correct;
+	int __first_nonopt;
+	int __last_nonopt;
+} getopt_data_a;
+char *optarg_a;
+
+static void exchange_a(char **argv, struct _getopt_data_a *d)
+{
+	int bottom = d->__first_nonopt;
+	int middle = d->__last_nonopt;
+	int top = d->optind;
+	char *tem;
+	while (top > middle && middle > bottom)
+	{
+		if (top - middle > middle - bottom)
+		{
+			int len = middle - bottom;
+			register int i;
+			for (i = 0; i < len; i++)
+			{
+				tem = argv[bottom + i];
+				argv[bottom + i] = argv[top - (middle - bottom) + i];
+				argv[top - (middle - bottom) + i] = tem;
+			}
+			top -= len;
+		}
+		else
+		{
+			int len = top - middle;
+			register int i;
+			for (i = 0; i < len; i++)
+			{
+				tem = argv[bottom + i];
+				argv[bottom + i] = argv[middle + i];
+				argv[middle + i] = tem;
+			}
+			bottom += len;
+		}
+	}
+	d->__first_nonopt += (d->optind - d->__last_nonopt);
+	d->__last_nonopt = d->optind;
+}
+static const char *_getopt_initialize_a (const char *optstring, struct _getopt_data_a *d, int posixly_correct)
+{
+	d->__first_nonopt = d->__last_nonopt = d->optind;
+	d->__nextchar = NULL;
+	d->__posixly_correct = posixly_correct | !!getenv("POSIXLY_CORRECT");
+	if (optstring[0] == '-')
+	{
+		d->__ordering = RETURN_IN_ORDER;
+		++optstring;
+	}
+	else if (optstring[0] == '+')
+	{
+		d->__ordering = REQUIRE_ORDER;
+		++optstring;
+	}
+	else if (d->__posixly_correct)
+		d->__ordering = REQUIRE_ORDER;
+	else
+		d->__ordering = PERMUTE;
+	return optstring;
+}
+int _getopt_internal_r_a (int argc, char *const *argv, const char *optstring, const struct option_a *longopts, int *longind, int long_only, struct _getopt_data_a *d, int posixly_correct)
+{
+	int print_errors = d->opterr;
+	if (argc < 1)
+		return -1;
+	d->optarg = NULL;
+	if (d->optind == 0 || !d->__initialized)
+	{
+		if (d->optind == 0)
+			d->optind = 1;
+		optstring = _getopt_initialize_a (optstring, d, posixly_correct);
+		d->__initialized = 1;
+	}
+	else if (optstring[0] == '-' || optstring[0] == '+')
+		optstring++;
+	if (optstring[0] == ':')
+		print_errors = 0;
+	if (d->__nextchar == NULL || *d->__nextchar == '\0')
+	{
+		if (d->__last_nonopt > d->optind)
+			d->__last_nonopt = d->optind;
+		if (d->__first_nonopt > d->optind)
+			d->__first_nonopt = d->optind;
+		if (d->__ordering == PERMUTE)
+		{
+			if (d->__first_nonopt != d->__last_nonopt && d->__last_nonopt != d->optind)
+				exchange_a ((char **) argv, d);
+			else if (d->__last_nonopt != d->optind)
+				d->__first_nonopt = d->optind;
+			while (d->optind < argc && (argv[d->optind][0] != '-' || argv[d->optind][1] == '\0'))
+				d->optind++;
+			d->__last_nonopt = d->optind;
+		}
+		if (d->optind != argc && !strcmp(argv[d->optind], "--"))
+		{
+			d->optind++;
+			if (d->__first_nonopt != d->__last_nonopt && d->__last_nonopt != d->optind)
+				exchange_a((char **) argv, d);
+			else if (d->__first_nonopt == d->__last_nonopt)
+				d->__first_nonopt = d->optind;
+			d->__last_nonopt = argc;
+			d->optind = argc;
+		}
+		if (d->optind == argc)
+		{
+			if (d->__first_nonopt != d->__last_nonopt)
+				d->optind = d->__first_nonopt;
+			return -1;
+		}
+		if ((argv[d->optind][0] != '-' || argv[d->optind][1] == '\0'))
+		{
+			if (d->__ordering == REQUIRE_ORDER)
+				return -1;
+			d->optarg = argv[d->optind++];
+			return 1;
+		}
+		d->__nextchar = (argv[d->optind] + 1 + (longopts != NULL && argv[d->optind][1] == '-'));
+	}
+	if (longopts != NULL && (argv[d->optind][1] == '-' || (long_only && (argv[d->optind][2] || !strchr(optstring, argv[d->optind][1])))))
+	{
+		char *nameend;
+		unsigned int namelen;
+		const struct option_a *p;
+		const struct option_a *pfound = NULL;
+		struct option_list
+		{
+			const struct option_a *p;
+			struct option_list *next;
+		} *ambig_list = NULL;
+		int exact = 0;
+		int indfound = -1;
+		int option_index;
+		for (nameend = d->__nextchar; *nameend && *nameend != '='; nameend++);
+		namelen = (unsigned int)(nameend - d->__nextchar);
+		for (p = longopts, option_index = 0; p->name; p++, option_index++)
+			if (!strncmp(p->name, d->__nextchar, namelen))
+			{
+				if (namelen == (unsigned int)strlen(p->name))
+				{
+					pfound = p;
+					indfound = option_index;
+					exact = 1;
+					break;
+				}
+				else if (pfound == NULL)
+				{
+					pfound = p;
+					indfound = option_index;
+				}
+				else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
+				{
+					struct option_list *newp = (struct option_list*)alloca(sizeof(*newp));
+					newp->p = p;
+					newp->next = ambig_list;
+					ambig_list = newp;
+				}
+			}
+			if (ambig_list != NULL && !exact)
+			{
+				if (print_errors)
+				{
+					struct option_list first;
+					first.p = pfound;
+					first.next = ambig_list;
+					ambig_list = &first;
+					fprintf (stderr, "%s: option '%s' is ambiguous; possibilities:", argv[0], argv[d->optind]);
+					do
+					{
+						fprintf (stderr, " '--%s'", ambig_list->p->name);
+						ambig_list = ambig_list->next;
+					}
+					while (ambig_list != NULL);
+					fputc ('\n', stderr);
+				}
+				d->__nextchar += strlen(d->__nextchar);
+				d->optind++;
+				d->optopt = 0;
+				return '?';
+			}
+			if (pfound != NULL)
+			{
+				option_index = indfound;
+				d->optind++;
+				if (*nameend)
+				{
+					if (pfound->has_arg)
+						d->optarg = nameend + 1;
+					else
+					{
+						if (print_errors)
+						{
+							if (argv[d->optind - 1][1] == '-')
+							{
+								fprintf(stderr, "%s: option '--%s' doesn't allow an argument\n",argv[0], pfound->name);
+							}
+							else
+							{
+								fprintf(stderr, "%s: option '%c%s' doesn't allow an argument\n",argv[0], argv[d->optind - 1][0],pfound->name);
+							}
+						}
+						d->__nextchar += strlen(d->__nextchar);
+						d->optopt = pfound->val;
+						return '?';
+					}
+				}
+				else if (pfound->has_arg == 1)
+				{
+					if (d->optind < argc)
+						d->optarg = argv[d->optind++];
+					else
+					{
+						if (print_errors)
+						{
+							fprintf(stderr,"%s: option '--%s' requires an argument\n",argv[0], pfound->name);
+						}
+						d->__nextchar += strlen(d->__nextchar);
+						d->optopt = pfound->val;
+						return optstring[0] == ':' ? ':' : '?';
+					}
+				}
+				d->__nextchar += strlen(d->__nextchar);
+				if (longind != NULL)
+					*longind = option_index;
+				if (pfound->flag)
+				{
+					*(pfound->flag) = pfound->val;
+					return 0;
+				}
+				return pfound->val;
+			}
+			if (!long_only || argv[d->optind][1] == '-' || strchr(optstring, *d->__nextchar) == NULL)
+			{
+				if (print_errors)
+				{
+					if (argv[d->optind][1] == '-')
+					{
+						fprintf(stderr, "%s: unrecognized option '--%s'\n",argv[0], d->__nextchar);
+					}
+					else
+					{
+						fprintf(stderr, "%s: unrecognized option '%c%s'\n",argv[0], argv[d->optind][0], d->__nextchar);
+					}
+				}
+				d->__nextchar = (char *)"";
+				d->optind++;
+				d->optopt = 0;
+				return '?';
+			}
+	}
+	{
+		char c = *d->__nextchar++;
+		char *temp = (char*)strchr(optstring, c);
+		if (*d->__nextchar == '\0')
+			++d->optind;
+		if (temp == NULL || c == ':' || c == ';')
+		{
+			if (print_errors)
+			{
+				fprintf(stderr, "%s: invalid option -- '%c'\n", argv[0], c);
+			}
+			d->optopt = c;
+			return '?';
+		}
+		if (temp[0] == 'W' && temp[1] == ';')
+		{
+			char *nameend;
+			const struct option_a *p;
+			const struct option_a *pfound = NULL;
+			int exact = 0;
+			int ambig = 0;
+			int indfound = 0;
+			int option_index;
+			if (longopts == NULL)
+				goto no_longs;
+			if (*d->__nextchar != '\0')
+			{
+				d->optarg = d->__nextchar;
+				d->optind++;
+			}
+			else if (d->optind == argc)
+			{
+				if (print_errors)
+				{
+					fprintf(stderr,"%s: option requires an argument -- '%c'\n",argv[0], c);
+				}
+				d->optopt = c;
+				if (optstring[0] == ':')
+					c = ':';
+				else
+					c = '?';
+				return c;
+			}
+			else
+				d->optarg = argv[d->optind++];
+			for (d->__nextchar = nameend = d->optarg; *nameend && *nameend != '='; nameend++);
+			for (p = longopts, option_index = 0; p->name; p++, option_index++)
+				if (!strncmp(p->name, d->__nextchar, nameend - d->__nextchar))
+				{
+					if ((unsigned int) (nameend - d->__nextchar) == strlen(p->name))
+					{
+						pfound = p;
+						indfound = option_index;
+						exact = 1;
+						break;
+					}
+					else if (pfound == NULL)
+					{
+						pfound = p;
+						indfound = option_index;
+					}
+					else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
+						ambig = 1;
+				}
+				if (ambig && !exact)
+				{
+					if (print_errors)
+					{
+						fprintf(stderr, "%s: option '-W %s' is ambiguous\n",argv[0], d->optarg);
+					}
+					d->__nextchar += strlen(d->__nextchar);
+					d->optind++;
+					return '?';
+				}
+				if (pfound != NULL)
+				{
+					option_index = indfound;
+					if (*nameend)
+					{
+						if (pfound->has_arg)
+							d->optarg = nameend + 1;
+						else
+						{
+							if (print_errors)
+							{
+								fprintf(stderr, "%s: option '-W %s' doesn't allow an argument\n",argv[0], pfound->name);
+							}
+							d->__nextchar += strlen(d->__nextchar);
+							return '?';
+						}
+					}
+					else if (pfound->has_arg == 1)
+					{
+						if (d->optind < argc)
+							d->optarg = argv[d->optind++];
+						else
+						{
+							if (print_errors)
+							{
+								fprintf(stderr, "%s: option '-W %s' requires an argument\n",argv[0], pfound->name);
+							}
+							d->__nextchar += strlen(d->__nextchar);
+							return optstring[0] == ':' ? ':' : '?';
+						}
+					}
+					else
+						d->optarg = NULL;
+					d->__nextchar += strlen(d->__nextchar);
+					if (longind != NULL)
+						*longind = option_index;
+					if (pfound->flag)
+					{
+						*(pfound->flag) = pfound->val;
+						return 0;
+					}
+					return pfound->val;
+				}
+no_longs:
+				d->__nextchar = NULL;
+				return 'W';
+		}
+		if (temp[1] == ':')
+		{
+			if (temp[2] == ':')
+			{
+				if (*d->__nextchar != '\0')
+				{
+					d->optarg = d->__nextchar;
+					d->optind++;
+				}
+				else
+					d->optarg = NULL;
+				d->__nextchar = NULL;
+			}
+			else
+			{
+				if (*d->__nextchar != '\0')
+				{
+					d->optarg = d->__nextchar;
+					d->optind++;
+				}
+				else if (d->optind == argc)
+				{
+					if (print_errors)
+					{
+						fprintf(stderr,"%s: option requires an argument -- '%c'\n",argv[0], c);
+					}
+					d->optopt = c;
+					if (optstring[0] == ':')
+						c = ':';
+					else
+						c = '?';
+				}
+				else
+					d->optarg = argv[d->optind++];
+				d->__nextchar = NULL;
+			}
+		}
+		return c;
+	}
+}
+int _getopt_internal_a (int argc, char *const *argv, const char *optstring, const struct option_a *longopts, int *longind, int long_only, int posixly_correct)
+{
+	int result;
+	getopt_data_a.optind = optind;
+	getopt_data_a.opterr = opterr;
+	result = _getopt_internal_r_a (argc, argv, optstring, longopts,longind, long_only, &getopt_data_a,posixly_correct);
+	optind = getopt_data_a.optind;
+	optarg_a = getopt_data_a.optarg;
+	optopt = getopt_data_a.optopt;
+	return result;
+}
+int getopt_a (int argc, char *const *argv, const char *optstring) _GETOPT_THROW
+{
+	return _getopt_internal_a (argc, argv, optstring, (const struct option_a *) 0, (int *) 0, 0, 0);
+}
+int getopt_long_a (int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index) _GETOPT_THROW
+{
+	return _getopt_internal_a (argc, argv, options, long_options, opt_index, 0, 0);
+}
+int getopt_long_only_a (int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index) _GETOPT_THROW
+{
+	return _getopt_internal_a (argc, argv, options, long_options, opt_index, 1, 0);
+}
+int _getopt_long_r_a (int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index, struct _getopt_data_a *d)
+{
+	return _getopt_internal_r_a (argc, argv, options, long_options, opt_index,0, d, 0);
+}
+int _getopt_long_only_r_a (int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index, struct _getopt_data_a *d)
+{
+	return _getopt_internal_r_a (argc, argv, options, long_options, opt_index, 1, d, 0);
+}
+
+//
+//
+//	Unicode Structures and Functions
+// 
+//
+
+static struct _getopt_data_w
+{
+	int optind;
+	int opterr;
+	int optopt;
+	wchar_t *optarg;
+	int __initialized;
+	wchar_t *__nextchar;
+	enum ENUM_ORDERING __ordering;
+	int __posixly_correct;
+	int __first_nonopt;
+	int __last_nonopt;
+} getopt_data_w;
+wchar_t *optarg_w;
+
+static void exchange_w(wchar_t **argv, struct _getopt_data_w *d)
+{
+	int bottom = d->__first_nonopt;
+	int middle = d->__last_nonopt;
+	int top = d->optind;
+	wchar_t *tem;
+	while (top > middle && middle > bottom)
+	{
+		if (top - middle > middle - bottom)
+		{
+			int len = middle - bottom;
+			register int i;
+			for (i = 0; i < len; i++)
+			{
+				tem = argv[bottom + i];
+				argv[bottom + i] = argv[top - (middle - bottom) + i];
+				argv[top - (middle - bottom) + i] = tem;
+			}
+			top -= len;
+		}
+		else
+		{
+			int len = top - middle;
+			register int i;
+			for (i = 0; i < len; i++)
+			{
+				tem = argv[bottom + i];
+				argv[bottom + i] = argv[middle + i];
+				argv[middle + i] = tem;
+			}
+			bottom += len;
+		}
+	}
+	d->__first_nonopt += (d->optind - d->__last_nonopt);
+	d->__last_nonopt = d->optind;
+}
+static const wchar_t *_getopt_initialize_w (const wchar_t *optstring, struct _getopt_data_w *d, int posixly_correct)
+{
+	d->__first_nonopt = d->__last_nonopt = d->optind;
+	d->__nextchar = NULL;
+	d->__posixly_correct = posixly_correct | !!_wgetenv(L"POSIXLY_CORRECT");
+	if (optstring[0] == L'-')
+	{
+		d->__ordering = RETURN_IN_ORDER;
+		++optstring;
+	}
+	else if (optstring[0] == L'+')
+	{
+		d->__ordering = REQUIRE_ORDER;
+		++optstring;
+	}
+	else if (d->__posixly_correct)
+		d->__ordering = REQUIRE_ORDER;
+	else
+		d->__ordering = PERMUTE;
+	return optstring;
+}
+int _getopt_internal_r_w (int argc, wchar_t *const *argv, const wchar_t *optstring, const struct option_w *longopts, int *longind, int long_only, struct _getopt_data_w *d, int posixly_correct)
+{
+	int print_errors = d->opterr;
+	if (argc < 1)
+		return -1;
+	d->optarg = NULL;
+	if (d->optind == 0 || !d->__initialized)
+	{
+		if (d->optind == 0)
+			d->optind = 1;
+		optstring = _getopt_initialize_w (optstring, d, posixly_correct);
+		d->__initialized = 1;
+	}
+	else if (optstring[0] == L'-' || optstring[0] == L'+')
+		optstring++;
+	if (optstring[0] == L':')
+		print_errors = 0;
+	if (d->__nextchar == NULL || *d->__nextchar == L'\0')
+	{
+		if (d->__last_nonopt > d->optind)
+			d->__last_nonopt = d->optind;
+		if (d->__first_nonopt > d->optind)
+			d->__first_nonopt = d->optind;
+		if (d->__ordering == PERMUTE)
+		{
+			if (d->__first_nonopt != d->__last_nonopt && d->__last_nonopt != d->optind)
+				exchange_w((wchar_t **) argv, d);
+			else if (d->__last_nonopt != d->optind)
+				d->__first_nonopt = d->optind;
+			while (d->optind < argc && (argv[d->optind][0] != L'-' || argv[d->optind][1] == L'\0'))
+				d->optind++;
+			d->__last_nonopt = d->optind;
+		}
+		if (d->optind != argc && !wcscmp(argv[d->optind], L"--"))
+		{
+			d->optind++;
+			if (d->__first_nonopt != d->__last_nonopt && d->__last_nonopt != d->optind)
+				exchange_w((wchar_t **) argv, d);
+			else if (d->__first_nonopt == d->__last_nonopt)
+				d->__first_nonopt = d->optind;
+			d->__last_nonopt = argc;
+			d->optind = argc;
+		}
+		if (d->optind == argc)
+		{
+			if (d->__first_nonopt != d->__last_nonopt)
+				d->optind = d->__first_nonopt;
+			return -1;
+		}
+		if ((argv[d->optind][0] != L'-' || argv[d->optind][1] == L'\0'))
+		{
+			if (d->__ordering == REQUIRE_ORDER)
+				return -1;
+			d->optarg = argv[d->optind++];
+			return 1;
+		}
+		d->__nextchar = (argv[d->optind] + 1 + (longopts != NULL && argv[d->optind][1] == L'-'));
+	}
+	if (longopts != NULL && (argv[d->optind][1] == L'-' || (long_only && (argv[d->optind][2] || !wcschr(optstring, argv[d->optind][1])))))
+	{
+		wchar_t *nameend;
+		unsigned int namelen;
+		const struct option_w *p;
+		const struct option_w *pfound = NULL;
+		struct option_list
+		{
+			const struct option_w *p;
+			struct option_list *next;
+		} *ambig_list = NULL;
+		int exact = 0;
+		int indfound = -1;
+		int option_index;
+		for (nameend = d->__nextchar; *nameend && *nameend != L'='; nameend++);
+		namelen = (unsigned int)(nameend - d->__nextchar);
+		for (p = longopts, option_index = 0; p->name; p++, option_index++)
+			if (!wcsncmp(p->name, d->__nextchar, namelen))
+			{
+				if (namelen == (unsigned int)wcslen(p->name))
+				{
+					pfound = p;
+					indfound = option_index;
+					exact = 1;
+					break;
+				}
+				else if (pfound == NULL)
+				{
+					pfound = p;
+					indfound = option_index;
+				}
+				else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
+				{
+					struct option_list *newp = (struct option_list*)alloca(sizeof(*newp));
+					newp->p = p;
+					newp->next = ambig_list;
+					ambig_list = newp;
+				}
+			}
+			if (ambig_list != NULL && !exact)
+			{
+				if (print_errors)
+				{						
+					struct option_list first;
+					first.p = pfound;
+					first.next = ambig_list;
+					ambig_list = &first;
+					fwprintf(stderr, L"%s: option '%s' is ambiguous; possibilities:", argv[0], argv[d->optind]);
+					do
+					{
+						fwprintf (stderr, L" '--%s'", ambig_list->p->name);
+						ambig_list = ambig_list->next;
+					}
+					while (ambig_list != NULL);
+					fputwc (L'\n', stderr);
+				}
+				d->__nextchar += wcslen(d->__nextchar);
+				d->optind++;
+				d->optopt = 0;
+				return L'?';
+			}
+			if (pfound != NULL)
+			{
+				option_index = indfound;
+				d->optind++;
+				if (*nameend)
+				{
+					if (pfound->has_arg)
+						d->optarg = nameend + 1;
+					else
+					{
+						if (print_errors)
+						{
+							if (argv[d->optind - 1][1] == L'-')
+							{
+								fwprintf(stderr, L"%s: option '--%s' doesn't allow an argument\n",argv[0], pfound->name);
+							}
+							else
+							{
+								fwprintf(stderr, L"%s: option '%c%s' doesn't allow an argument\n",argv[0], argv[d->optind - 1][0],pfound->name);
+							}
+						}
+						d->__nextchar += wcslen(d->__nextchar);
+						d->optopt = pfound->val;
+						return L'?';
+					}
+				}
+				else if (pfound->has_arg == 1)
+				{
+					if (d->optind < argc)
+						d->optarg = argv[d->optind++];
+					else
+					{
+						if (print_errors)
+						{
+							fwprintf(stderr,L"%s: option '--%s' requires an argument\n",argv[0], pfound->name);
+						}
+						d->__nextchar += wcslen(d->__nextchar);
+						d->optopt = pfound->val;
+						return optstring[0] == L':' ? L':' : L'?';
+					}
+				}
+				d->__nextchar += wcslen(d->__nextchar);
+				if (longind != NULL)
+					*longind = option_index;
+				if (pfound->flag)
+				{
+					*(pfound->flag) = pfound->val;
+					return 0;
+				}
+				return pfound->val;
+			}
+			if (!long_only || argv[d->optind][1] == L'-' || wcschr(optstring, *d->__nextchar) == NULL)
+			{
+				if (print_errors)
+				{
+					if (argv[d->optind][1] == L'-')
+					{
+						fwprintf(stderr, L"%s: unrecognized option '--%s'\n",argv[0], d->__nextchar);
+					}
+					else
+					{
+						fwprintf(stderr, L"%s: unrecognized option '%c%s'\n",argv[0], argv[d->optind][0], d->__nextchar);
+					}
+				}
+				d->__nextchar = (wchar_t *)L"";
+				d->optind++;
+				d->optopt = 0;
+				return L'?';
+			}
+	}
+	{
+		wchar_t c = *d->__nextchar++;
+		wchar_t *temp = (wchar_t*)wcschr(optstring, c);
+		if (*d->__nextchar == L'\0')
+			++d->optind;
+		if (temp == NULL || c == L':' || c == L';')
+		{
+			if (print_errors)
+			{
+				fwprintf(stderr, L"%s: invalid option -- '%c'\n", argv[0], c);
+			}
+			d->optopt = c;
+			return L'?';
+		}
+		if (temp[0] == L'W' && temp[1] == L';')
+		{
+			wchar_t *nameend;
+			const struct option_w *p;
+			const struct option_w *pfound = NULL;
+			int exact = 0;
+			int ambig = 0;
+			int indfound = 0;
+			int option_index;
+			if (longopts == NULL)
+				goto no_longs;
+			if (*d->__nextchar != L'\0')
+			{
+				d->optarg = d->__nextchar;
+				d->optind++;
+			}
+			else if (d->optind == argc)
+			{
+				if (print_errors)
+				{
+					fwprintf(stderr,L"%s: option requires an argument -- '%c'\n",argv[0], c);
+				}
+				d->optopt = c;
+				if (optstring[0] == L':')
+					c = L':';
+				else
+					c = L'?';
+				return c;
+			}
+			else
+				d->optarg = argv[d->optind++];
+			for (d->__nextchar = nameend = d->optarg; *nameend && *nameend != L'='; nameend++);
+			for (p = longopts, option_index = 0; p->name; p++, option_index++)
+				if (!wcsncmp(p->name, d->__nextchar, nameend - d->__nextchar))
+				{
+					if ((unsigned int) (nameend - d->__nextchar) == wcslen(p->name))
+					{
+						pfound = p;
+						indfound = option_index;
+						exact = 1;
+						break;
+					}
+					else if (pfound == NULL)
+					{
+						pfound = p;
+						indfound = option_index;
+					}
+					else if (long_only || pfound->has_arg != p->has_arg || pfound->flag != p->flag || pfound->val != p->val)
+						ambig = 1;
+				}
+				if (ambig && !exact)
+				{
+					if (print_errors)
+					{
+						fwprintf(stderr, L"%s: option '-W %s' is ambiguous\n",argv[0], d->optarg);
+					}
+					d->__nextchar += wcslen(d->__nextchar);
+					d->optind++;
+					return L'?';
+				}
+				if (pfound != NULL)
+				{
+					option_index = indfound;
+					if (*nameend)
+					{
+						if (pfound->has_arg)
+							d->optarg = nameend + 1;
+						else
+						{
+							if (print_errors)
+							{
+								fwprintf(stderr, L"%s: option '-W %s' doesn't allow an argument\n",argv[0], pfound->name);
+							}
+							d->__nextchar += wcslen(d->__nextchar);
+							return L'?';
+						}
+					}
+					else if (pfound->has_arg == 1)
+					{
+						if (d->optind < argc)
+							d->optarg = argv[d->optind++];
+						else
+						{
+							if (print_errors)
+							{
+								fwprintf(stderr, L"%s: option '-W %s' requires an argument\n",argv[0], pfound->name);
+							}
+							d->__nextchar += wcslen(d->__nextchar);
+							return optstring[0] == L':' ? L':' : L'?';
+						}
+					}
+					else
+						d->optarg = NULL;
+					d->__nextchar += wcslen(d->__nextchar);
+					if (longind != NULL)
+						*longind = option_index;
+					if (pfound->flag)
+					{
+						*(pfound->flag) = pfound->val;
+						return 0;
+					}
+					return pfound->val;
+				}
+no_longs:
+				d->__nextchar = NULL;
+				return L'W';
+		}
+		if (temp[1] == L':')
+		{
+			if (temp[2] == L':')
+			{
+				if (*d->__nextchar != L'\0')
+				{
+					d->optarg = d->__nextchar;
+					d->optind++;
+				}
+				else
+					d->optarg = NULL;
+				d->__nextchar = NULL;
+			}
+			else
+			{
+				if (*d->__nextchar != L'\0')
+				{
+					d->optarg = d->__nextchar;
+					d->optind++;
+				}
+				else if (d->optind == argc)
+				{
+					if (print_errors)
+					{
+						fwprintf(stderr,L"%s: option requires an argument -- '%c'\n",argv[0], c);
+					}
+					d->optopt = c;
+					if (optstring[0] == L':')
+						c = L':';
+					else
+						c = L'?';
+				}
+				else
+					d->optarg = argv[d->optind++];
+				d->__nextchar = NULL;
+			}
+		}
+		return c;
+	}
+}
+int _getopt_internal_w (int argc, wchar_t *const *argv, const wchar_t *optstring, const struct option_w *longopts, int *longind, int long_only, int posixly_correct)
+{
+	int result;
+	getopt_data_w.optind = optind;
+	getopt_data_w.opterr = opterr;
+	result = _getopt_internal_r_w (argc, argv, optstring, longopts,longind, long_only, &getopt_data_w,posixly_correct);
+	optind = getopt_data_w.optind;
+	optarg_w = getopt_data_w.optarg;
+	optopt = getopt_data_w.optopt;
+	return result;
+}
+int getopt_w (int argc, wchar_t *const *argv, const wchar_t *optstring) _GETOPT_THROW
+{
+	return _getopt_internal_w (argc, argv, optstring, (const struct option_w *) 0, (int *) 0, 0, 0);
+}
+int getopt_long_w (int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW
+{
+	return _getopt_internal_w (argc, argv, options, long_options, opt_index, 0, 0);
+}
+int getopt_long_only_w (int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW
+{
+	return _getopt_internal_w (argc, argv, options, long_options, opt_index, 1, 0);
+}
+int _getopt_long_r_w (int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index, struct _getopt_data_w *d)
+{
+	return _getopt_internal_r_w (argc, argv, options, long_options, opt_index,0, d, 0);
+}
+int _getopt_long_only_r_w (int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index, struct _getopt_data_w *d)
+{
+	return _getopt_internal_r_w (argc, argv, options, long_options, opt_index, 1, d, 0);
+}

--- a/msvc/getopt/getopt.h
+++ b/msvc/getopt/getopt.h
@@ -1,0 +1,135 @@
+/* Getopt for Microsoft C
+This code is a modification of the Free Software Foundation, Inc.
+Getopt library for parsing command line argument the purpose was
+to provide a Microsoft Visual C friendly derivative. This code
+provides functionality for both Unicode and Multibyte builds.
+
+Date: 02/03/2011 - Ludvik Jerabek - Initial Release
+Version: 1.0
+Comment: Supports getopt, getopt_long, and getopt_long_only
+and POSIXLY_CORRECT environment flag
+License: LGPL
+
+Revisions:
+
+02/03/2011 - Ludvik Jerabek - Initial Release
+02/20/2011 - Ludvik Jerabek - Fixed compiler warnings at Level 4
+07/05/2011 - Ludvik Jerabek - Added no_argument, required_argument, optional_argument defs
+08/03/2011 - Ludvik Jerabek - Fixed non-argument runtime bug which caused runtime exception
+08/09/2011 - Ludvik Jerabek - Added code to export functions for DLL and LIB
+02/15/2012 - Ludvik Jerabek - Fixed _GETOPT_THROW definition missing in implementation file
+08/01/2012 - Ludvik Jerabek - Created separate functions for char and wchar_t characters so single dll can do both unicode and ansi
+10/15/2012 - Ludvik Jerabek - Modified to match latest GNU features
+
+**DISCLAIMER**
+THIS MATERIAL IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING, BUT Not LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, OR NON-INFRINGEMENT. SOME JURISDICTIONS DO NOT ALLOW THE
+EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSION MAY NOT
+APPLY TO YOU. IN NO EVENT WILL I BE LIABLE TO ANY PARTY FOR ANY
+DIRECT, INDIRECT, SPECIAL OR OTHER CONSEQUENTIAL DAMAGES FOR ANY
+USE OF THIS MATERIAL INCLUDING, WITHOUT LIMITATION, ANY LOST
+PROFITS, BUSINESS INTERRUPTION, LOSS OF PROGRAMS OR OTHER DATA ON
+YOUR INFORMATION HANDLING SYSTEM OR OTHERWISE, EVEN If WE ARE
+EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+*/
+#ifndef __GETOPT_H_
+	#define __GETOPT_H_
+
+	#ifdef _GETOPT_API
+		#undef _GETOPT_API
+	#endif
+
+	#if defined(EXPORTS_GETOPT) && defined(STATIC_GETOPT)
+		#error "The preprocessor definitions of EXPORTS_GETOPT and STATIC_GETOPT can only be used individually"
+	#elif defined(STATIC_GETOPT)
+		#pragma message("Warning static builds of getopt violate the Lesser GNU Public License")
+		#define _GETOPT_API
+	#elif defined(EXPORTS_GETOPT)
+		#pragma message("Exporting getopt library")
+		#define _GETOPT_API __declspec(dllexport)
+	#else
+		#pragma message("Importing getopt library")
+		#define _GETOPT_API __declspec(dllimport)
+	#endif
+
+	// Change behavior for C\C++
+	#ifdef __cplusplus
+		#define _BEGIN_EXTERN_C extern "C" {
+		#define _END_EXTERN_C }
+		#define _GETOPT_THROW throw()
+	#else
+		#define _BEGIN_EXTERN_C
+		#define _END_EXTERN_C
+		#define _GETOPT_THROW
+	#endif
+
+	// Standard GNU options
+	#define	null_argument		0	/*Argument Null*/
+	#define	no_argument			0	/*Argument Switch Only*/
+	#define required_argument	1	/*Argument Required*/
+	#define optional_argument	2	/*Argument Optional*/	
+
+	// Shorter Options
+	#define ARG_NULL	0	/*Argument Null*/
+	#define ARG_NONE	0	/*Argument Switch Only*/
+	#define ARG_REQ		1	/*Argument Required*/
+	#define ARG_OPT		2	/*Argument Optional*/
+
+	#include <string.h>
+	#include <wchar.h>
+
+_BEGIN_EXTERN_C
+
+	extern _GETOPT_API int optind;
+	extern _GETOPT_API int opterr;
+	extern _GETOPT_API int optopt;
+
+	// Ansi
+	struct option_a
+	{
+		const char* name;
+		int has_arg;
+		int *flag;
+		char val;
+	};
+	extern _GETOPT_API char *optarg_a;
+	extern _GETOPT_API int getopt_a(int argc, char *const *argv, const char *optstring) _GETOPT_THROW;
+	extern _GETOPT_API int getopt_long_a(int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index) _GETOPT_THROW;
+	extern _GETOPT_API int getopt_long_only_a(int argc, char *const *argv, const char *options, const struct option_a *long_options, int *opt_index) _GETOPT_THROW;
+
+	// Unicode
+	struct option_w
+	{
+		const wchar_t* name;
+		int has_arg;
+		int *flag;
+		wchar_t val;
+	};
+	extern _GETOPT_API wchar_t *optarg_w;
+	extern _GETOPT_API int getopt_w(int argc, wchar_t *const *argv, const wchar_t *optstring) _GETOPT_THROW;
+	extern _GETOPT_API int getopt_long_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;
+	extern _GETOPT_API int getopt_long_only_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;	
+	
+_END_EXTERN_C
+
+	#undef _BEGIN_EXTERN_C
+	#undef _END_EXTERN_C
+	#undef _GETOPT_THROW
+	#undef _GETOPT_API
+
+	#ifdef _UNICODE
+		#define getopt getopt_w
+		#define getopt_long getopt_long_w
+		#define getopt_long_only getopt_long_only_w
+		#define option option_w
+		#define optarg optarg_w
+	#else
+		#define getopt getopt_a
+		#define getopt_long getopt_long_a
+		#define getopt_long_only getopt_long_only_a
+		#define option option_a
+		#define optarg optarg_a
+	#endif
+#endif  // __GETOPT_H_

--- a/msvc/inmemorybenchmark.vcxproj
+++ b/msvc/inmemorybenchmark.vcxproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{635B18E0-2AD7-45A7-914E-831A6B711F89}</ProjectGuid>
+    <RootNamespace>inmemorybenchmark</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers;./getopt</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers;./getopt</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\inmemorybenchmark.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastPFor.vcxproj">
+      <Project>{42d8aba4-fc4e-426c-a833-d64d06081f92}</Project>
+    </ProjectReference>
+    <ProjectReference Include="getopt.vcxproj">
+      <Project>{d0d480b3-816e-4a04-8ae4-75210f8701e0}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/unit.vcxproj
+++ b/msvc/unit.vcxproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{8B2ED3AF-F2E8-480B-BE7D-7B6E44DC4BFE}</ProjectGuid>
+    <RootNamespace>unit</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>../headers</AdditionalIncludeDirectories>
+      <ProgramDataBaseFileName>$(IntDir)$(ProjectName).pdb</ProgramDataBaseFileName>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\unit.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="FastPFor.vcxproj">
+      <Project>{42d8aba4-fc4e-426c-a833-d64d06081f92}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Changes 2015-08-30:

/headers/codecfactory.h - avoiding compile issue with MSVC2015, added a new codec.
/headers/deltautil.h - avoiding compile issue with MSVC2015, making output fit on the screen.
/headers/memutil.h - added the missing required constructor.
/headers/simple9_rle.h - Added a new Simple9-like codec (see file header for details).
/headers/simple8b_rle.h - Cleaned up the Simple8b-like codec (see file header for details).
 - Extracted the Simple8b-like codec in a separate class to facilitate code reuse.
 - Breaking change: Reversed bit-packing endianness to improve decoding performance.

/msvc/* - Re-added MSVC2015 projects/solution as the CMake-generated ones were too big.
