### PR TITLE
Removed constexpr from variable declaration

### DIFF
--- a/src/bitpacking.cpp
+++ b/src/bitpacking.cpp
@@ -17,7 +17,7 @@ template<uint8_t DELTA, uint8_t SHR>
   *out = (*in) >> SHR;
   ++in;
 
-  constexpr uint8_t NEXT_SHR = SHR + DELTA - 32;
+  static const uint8_t NEXT_SHR = SHR + DELTA - 32;
   *out |= ((*in) % (1U << NEXT_SHR)) << (32 - SHR);
 }
 


### PR DESCRIPTION
Constexpr is redefined as inlined in https://github.com/lemire/FastPFor/blob/48035758c387ec6b10a826df0d18d51becb7b382/headers/common.h

This is forbidden by MSVC, indeed the code does not compile on Windows.
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2433