### PR TITLE
removed incorrect bits()

### DIFF
--- a/headers/simple8b_rle.h
+++ b/headers/simple8b_rle.h
@@ -83,12 +83,6 @@ class Simple8b_Codec {
   static const uint64_t RLE_MAX_VALUE_MASK = (1ULL << RLE_MAX_VALUE_BITS) - 1;
   static const uint64_t RLE_MAX_COUNT_MASK = (1ULL << RLE_MAX_COUNT_BITS) - 1;
 
-  static uint32_t bits(uint32_t i) {
-    i = i - ((i >> 1) & 0x55555555);
-    i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
-    return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
-  }
-
   // check if next integer repeats, return count if packs better, otherwize 0
   static uint32_t tryRunLength(const uint32_t *input, uint32_t pos,
                                uint32_t count) {

--- a/headers/simple9_rle.h
+++ b/headers/simple9_rle.h
@@ -102,12 +102,6 @@ class Simple9_Codec {
   static const uint32_t RLE_MAX_VALUE_MASK = (1U << RLE_MAX_VALUE_BITS) - 1;
   static const uint32_t RLE_MAX_COUNT_MASK = (1U << RLE_MAX_COUNT_BITS) - 1;
 
-  static uint32_t bits(uint32_t i) {
-    i = i - ((i >> 1) & 0x55555555);
-    i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
-    return (((i + (i >> 4)) & 0x0F0F0F0F) * 0x01010101) >> 24;
-  }
-
   // check if next integer repeats, return count if packs better, otherwize 0
   static uint32_t tryRunLength(const uint32_t *input, uint32_t pos,
                                uint32_t count) {


### PR DESCRIPTION
Fixing old bug, better late than never.
- before:  `bits=popcnt`
- after: `bits=logb`