### PR TITLE
Add support for 64-bit integers for FastPFor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ include(AppendCompilerFlags)
 project(FastPFor CXX C)
 set(PROJECT_URL "https://github.com/lemire/FastPFOR")
 set(PROJECT_DESCRIPTION "The FastPFOR C++ library: Fast integer compression")
+
 include(DetectCPUFeatures)
 #
 # Runs compiler with "-dumpversion" and parses major/minor
@@ -145,6 +146,40 @@ else()
     target_link_libraries(inmemorybenchmarksnappy FastPFor ${snappy_LIBRARIES})
 endif()
 
+# Download and unpack googletest at configure time
+configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build .
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+  message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
+
+# Prevent GoogleTest from overriding our compiler/linker options
+# when building with Visual Studio
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+# Add googletest directly to our build. This adds
+# the following targets: gtest, gtest_main, gmock
+# and gmock_main
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                 EXCLUDE_FROM_ALL)
+
+# The gtest/gmock targets carry header search path
+# dependencies automatically when using CMake 2.8.11 or
+# later. Otherwise we have to add them here ourselves.
+if(CMAKE_VERSION VERSION_LESS 2.8.11)
+    include_directories("${gtest_SOURCE_DIR}/include"
+                        "${gmock_SOURCE_DIR}/include")
+endif()
+
 add_executable(codecs src/codecs.cpp)
 target_link_libraries(codecs FastPFor)
 
@@ -157,3 +192,10 @@ target_link_libraries(inmemorybenchmark FastPFor)
 add_executable(unit src/unit.cpp)
 target_link_libraries(unit FastPFor)
 add_custom_target(check unit DEPENDS unit)
+
+add_executable(fastpor_unittest
+    unittest/test_composite.cpp
+    unittest/test_driver.cpp
+    unittest/test_fastpfor.cpp
+    unittest/test_variablebyte.cpp)
+target_link_libraries(fastpor_unittest gtest_main FastPFor)

--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.8.0
+    SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
+    BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+)

--- a/headers/bitpacking.h
+++ b/headers/bitpacking.h
@@ -65,6 +65,127 @@ void __fastunpack31(const uint32_t *__restrict__ in,
 void __fastunpack32(const uint32_t *__restrict__ in,
                     uint32_t *__restrict__ out);
 
+void __fastunpack0(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack1(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack2(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack3(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack4(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack5(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack6(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack7(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack8(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack9(const uint32_t *__restrict__ in, uint64_t *__restrict__ out);
+void __fastunpack10(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack11(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack12(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack13(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack14(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack15(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack16(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack17(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack18(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack19(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack20(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack21(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack22(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack23(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack24(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack25(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack26(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack27(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack28(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack29(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack30(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack31(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack32(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack33(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack34(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack35(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack36(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack37(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack38(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack39(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack40(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack41(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack42(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack43(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack44(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack45(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack46(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack47(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack48(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack49(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack50(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack51(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack52(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack53(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack54(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack55(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack56(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack57(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack58(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack59(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack60(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack61(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack62(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack63(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+void __fastunpack64(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out);
+
 void __fastpack0(const uint32_t *__restrict__ in, uint32_t *__restrict__ out);
 void __fastpack1(const uint32_t *__restrict__ in, uint32_t *__restrict__ out);
 void __fastpack2(const uint32_t *__restrict__ in, uint32_t *__restrict__ out);
@@ -98,6 +219,72 @@ void __fastpack29(const uint32_t *__restrict__ in, uint32_t *__restrict__ out);
 void __fastpack30(const uint32_t *__restrict__ in, uint32_t *__restrict__ out);
 void __fastpack31(const uint32_t *__restrict__ in, uint32_t *__restrict__ out);
 void __fastpack32(const uint32_t *__restrict__ in, uint32_t *__restrict__ out);
+
+void __fastpack0(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack1(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack2(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack3(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack4(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack5(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack6(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack7(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack8(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack9(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack10(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack11(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack12(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack13(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack14(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack15(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack16(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack17(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack18(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack19(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack20(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack21(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack22(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack23(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack24(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack25(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack26(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack27(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack28(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack29(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack30(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack31(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack32(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack33(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack34(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack35(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack36(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack37(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack38(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack39(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack40(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack41(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack42(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack43(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack44(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack45(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack46(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack47(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack48(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack49(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack50(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack51(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack52(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack53(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack54(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack55(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack56(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack57(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack58(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack59(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack60(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack61(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack62(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack63(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
+void __fastpack64(const uint64_t *__restrict__ in, uint32_t *__restrict__ out);
 
 void __fastpackwithoutmask0(const uint32_t *__restrict__ in,
                             uint32_t *__restrict__ out);
@@ -164,6 +351,137 @@ void __fastpackwithoutmask30(const uint32_t *__restrict__ in,
 void __fastpackwithoutmask31(const uint32_t *__restrict__ in,
                              uint32_t *__restrict__ out);
 void __fastpackwithoutmask32(const uint32_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+
+void __fastpackwithoutmask0(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask1(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask2(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask3(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask4(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask5(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask6(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask7(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask8(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask9(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out);
+void __fastpackwithoutmask10(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask11(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask12(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask13(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask14(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask15(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask16(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask17(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask18(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask19(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask20(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask21(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask22(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask23(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask24(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask25(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask26(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask27(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask28(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask29(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask30(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask31(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask32(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask33(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask34(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask35(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask36(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask37(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask38(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask39(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask40(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask41(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask42(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask43(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask44(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask45(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask46(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask47(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask48(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask49(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask50(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask51(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask52(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask53(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask54(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask55(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask56(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask57(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask58(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask59(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask60(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask61(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask62(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask63(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out);
+void __fastpackwithoutmask64(const uint64_t *__restrict__ in,
                              uint32_t *__restrict__ out);
 
 #endif // BITPACKING

--- a/headers/bitpackinghelpers.h
+++ b/headers/bitpackinghelpers.h
@@ -122,6 +122,212 @@ inline void fastunpack(const uint32_t *__restrict__ in,
   }
 }
 
+inline void fastunpack(const uint32_t *__restrict__ in,
+                       uint64_t *__restrict__ out, const uint32_t bit) {
+  // Could have used function pointers instead of switch.
+  // Switch calls do offer the compiler more opportunities for optimization in
+  // theory. In this case, it makes no difference with a good compiler.
+  switch (bit) {
+  case 0:
+    __fastunpack0(in, out);
+    break;
+  case 1:
+    __fastunpack1(in, out);
+    break;
+  case 2:
+    __fastunpack2(in, out);
+    break;
+  case 3:
+    __fastunpack3(in, out);
+    break;
+  case 4:
+    __fastunpack4(in, out);
+    break;
+  case 5:
+    __fastunpack5(in, out);
+    break;
+  case 6:
+    __fastunpack6(in, out);
+    break;
+  case 7:
+    __fastunpack7(in, out);
+    break;
+  case 8:
+    __fastunpack8(in, out);
+    break;
+  case 9:
+    __fastunpack9(in, out);
+    break;
+  case 10:
+    __fastunpack10(in, out);
+    break;
+  case 11:
+    __fastunpack11(in, out);
+    break;
+  case 12:
+    __fastunpack12(in, out);
+    break;
+  case 13:
+    __fastunpack13(in, out);
+    break;
+  case 14:
+    __fastunpack14(in, out);
+    break;
+  case 15:
+    __fastunpack15(in, out);
+    break;
+  case 16:
+    __fastunpack16(in, out);
+    break;
+  case 17:
+    __fastunpack17(in, out);
+    break;
+  case 18:
+    __fastunpack18(in, out);
+    break;
+  case 19:
+    __fastunpack19(in, out);
+    break;
+  case 20:
+    __fastunpack20(in, out);
+    break;
+  case 21:
+    __fastunpack21(in, out);
+    break;
+  case 22:
+    __fastunpack22(in, out);
+    break;
+  case 23:
+    __fastunpack23(in, out);
+    break;
+  case 24:
+    __fastunpack24(in, out);
+    break;
+  case 25:
+    __fastunpack25(in, out);
+    break;
+  case 26:
+    __fastunpack26(in, out);
+    break;
+  case 27:
+    __fastunpack27(in, out);
+    break;
+  case 28:
+    __fastunpack28(in, out);
+    break;
+  case 29:
+    __fastunpack29(in, out);
+    break;
+  case 30:
+    __fastunpack30(in, out);
+    break;
+  case 31:
+    __fastunpack31(in, out);
+    break;
+  case 32:
+    __fastunpack32(in, out);
+    break;
+  case 33:
+    __fastunpack33(in, out);
+    break;
+  case 34:
+    __fastunpack34(in, out);
+    break;
+  case 35:
+    __fastunpack35(in, out);
+    break;
+  case 36:
+    __fastunpack36(in, out);
+    break;
+  case 37:
+    __fastunpack37(in, out);
+    break;
+  case 38:
+    __fastunpack38(in, out);
+    break;
+  case 39:
+    __fastunpack39(in, out);
+    break;
+  case 40:
+    __fastunpack40(in, out);
+    break;
+  case 41:
+    __fastunpack41(in, out);
+    break;
+  case 42:
+    __fastunpack42(in, out);
+    break;
+  case 43:
+    __fastunpack43(in, out);
+    break;
+  case 44:
+    __fastunpack44(in, out);
+    break;
+  case 45:
+    __fastunpack45(in, out);
+    break;
+  case 46:
+    __fastunpack46(in, out);
+    break;
+  case 47:
+    __fastunpack47(in, out);
+    break;
+  case 48:
+    __fastunpack48(in, out);
+    break;
+  case 49:
+    __fastunpack49(in, out);
+    break;
+  case 50:
+    __fastunpack50(in, out);
+    break;
+  case 51:
+    __fastunpack51(in, out);
+    break;
+  case 52:
+    __fastunpack52(in, out);
+    break;
+  case 53:
+    __fastunpack53(in, out);
+    break;
+  case 54:
+    __fastunpack54(in, out);
+    break;
+  case 55:
+    __fastunpack55(in, out);
+    break;
+  case 56:
+    __fastunpack56(in, out);
+    break;
+  case 57:
+    __fastunpack57(in, out);
+    break;
+  case 58:
+    __fastunpack58(in, out);
+    break;
+  case 59:
+    __fastunpack59(in, out);
+    break;
+  case 60:
+    __fastunpack60(in, out);
+    break;
+  case 61:
+    __fastunpack61(in, out);
+    break;
+  case 62:
+    __fastunpack62(in, out);
+    break;
+  case 63:
+    __fastunpack63(in, out);
+    break;
+  case 64:
+    __fastunpack64(in, out);
+    break;
+  default:
+    break;
+  }
+}
+
 inline void fastpack(const uint32_t *__restrict__ in,
                      uint32_t *__restrict__ out, const uint32_t bit) {
   // Could have used function pointers instead of switch.
@@ -226,6 +432,209 @@ inline void fastpack(const uint32_t *__restrict__ in,
     break;
   case 32:
     __fastpack32(in, out);
+    break;
+  default:
+    break;
+  }
+}
+
+inline void fastpack(const uint64_t *__restrict__ in,
+                     uint32_t *__restrict__ out, const uint32_t bit) {
+  switch (bit) {
+  case 0:
+    __fastpack0(in, out);
+    break;
+  case 1:
+    __fastpack1(in, out);
+    break;
+  case 2:
+    __fastpack2(in, out);
+    break;
+  case 3:
+    __fastpack3(in, out);
+    break;
+  case 4:
+    __fastpack4(in, out);
+    break;
+  case 5:
+    __fastpack5(in, out);
+    break;
+  case 6:
+    __fastpack6(in, out);
+    break;
+  case 7:
+    __fastpack7(in, out);
+    break;
+  case 8:
+    __fastpack8(in, out);
+    break;
+  case 9:
+    __fastpack9(in, out);
+    break;
+  case 10:
+    __fastpack10(in, out);
+    break;
+  case 11:
+    __fastpack11(in, out);
+    break;
+  case 12:
+    __fastpack12(in, out);
+    break;
+  case 13:
+    __fastpack13(in, out);
+    break;
+  case 14:
+    __fastpack14(in, out);
+    break;
+  case 15:
+    __fastpack15(in, out);
+    break;
+  case 16:
+    __fastpack16(in, out);
+    break;
+  case 17:
+    __fastpack17(in, out);
+    break;
+  case 18:
+    __fastpack18(in, out);
+    break;
+  case 19:
+    __fastpack19(in, out);
+    break;
+  case 20:
+    __fastpack20(in, out);
+    break;
+  case 21:
+    __fastpack21(in, out);
+    break;
+  case 22:
+    __fastpack22(in, out);
+    break;
+  case 23:
+    __fastpack23(in, out);
+    break;
+  case 24:
+    __fastpack24(in, out);
+    break;
+  case 25:
+    __fastpack25(in, out);
+    break;
+  case 26:
+    __fastpack26(in, out);
+    break;
+  case 27:
+    __fastpack27(in, out);
+    break;
+  case 28:
+    __fastpack28(in, out);
+    break;
+  case 29:
+    __fastpack29(in, out);
+    break;
+  case 30:
+    __fastpack30(in, out);
+    break;
+  case 31:
+    __fastpack31(in, out);
+    break;
+  case 32:
+    __fastpack32(in, out);
+    break;
+  case 33:
+    __fastpack33(in, out);
+    break;
+  case 34:
+    __fastpack34(in, out);
+    break;
+  case 35:
+    __fastpack35(in, out);
+    break;
+  case 36:
+    __fastpack36(in, out);
+    break;
+  case 37:
+    __fastpack37(in, out);
+    break;
+  case 38:
+    __fastpack38(in, out);
+    break;
+  case 39:
+    __fastpack39(in, out);
+    break;
+  case 40:
+    __fastpack40(in, out);
+    break;
+  case 41:
+    __fastpack41(in, out);
+    break;
+  case 42:
+    __fastpack42(in, out);
+    break;
+  case 43:
+    __fastpack43(in, out);
+    break;
+  case 44:
+    __fastpack44(in, out);
+    break;
+  case 45:
+    __fastpack45(in, out);
+    break;
+  case 46:
+    __fastpack46(in, out);
+    break;
+  case 47:
+    __fastpack47(in, out);
+    break;
+  case 48:
+    __fastpack48(in, out);
+    break;
+  case 49:
+    __fastpack49(in, out);
+    break;
+  case 50:
+    __fastpack50(in, out);
+    break;
+  case 51:
+    __fastpack51(in, out);
+    break;
+  case 52:
+    __fastpack52(in, out);
+    break;
+  case 53:
+    __fastpack53(in, out);
+    break;
+  case 54:
+    __fastpack54(in, out);
+    break;
+  case 55:
+    __fastpack55(in, out);
+    break;
+  case 56:
+    __fastpack56(in, out);
+    break;
+  case 57:
+    __fastpack57(in, out);
+    break;
+  case 58:
+    __fastpack58(in, out);
+    break;
+  case 59:
+    __fastpack59(in, out);
+    break;
+  case 60:
+    __fastpack60(in, out);
+    break;
+  case 61:
+    __fastpack61(in, out);
+    break;
+  case 62:
+    __fastpack62(in, out);
+    break;
+  case 63:
+    __fastpack63(in, out);
+    break;
+  case 64:
+    __fastpack64(in, out);
     break;
   default:
     break;
@@ -344,8 +753,212 @@ inline void fastpackwithoutmask(const uint32_t *__restrict__ in,
   }
 }
 
-template <uint32_t BlockSize>
-uint32_t *packblockup(const uint32_t *source, uint32_t *out,
+inline void fastpackwithoutmask(const uint64_t *__restrict__ in,
+                                uint32_t *__restrict__ out,
+                                const uint32_t bit) {
+  switch (bit) {
+  case 0:
+    __fastpackwithoutmask0(in, out);
+    break;
+  case 1:
+    __fastpackwithoutmask1(in, out);
+    break;
+  case 2:
+    __fastpackwithoutmask2(in, out);
+    break;
+  case 3:
+    __fastpackwithoutmask3(in, out);
+    break;
+  case 4:
+    __fastpackwithoutmask4(in, out);
+    break;
+  case 5:
+    __fastpackwithoutmask5(in, out);
+    break;
+  case 6:
+    __fastpackwithoutmask6(in, out);
+    break;
+  case 7:
+    __fastpackwithoutmask7(in, out);
+    break;
+  case 8:
+    __fastpackwithoutmask8(in, out);
+    break;
+  case 9:
+    __fastpackwithoutmask9(in, out);
+    break;
+  case 10:
+    __fastpackwithoutmask10(in, out);
+    break;
+  case 11:
+    __fastpackwithoutmask11(in, out);
+    break;
+  case 12:
+    __fastpackwithoutmask12(in, out);
+    break;
+  case 13:
+    __fastpackwithoutmask13(in, out);
+    break;
+  case 14:
+    __fastpackwithoutmask14(in, out);
+    break;
+  case 15:
+    __fastpackwithoutmask15(in, out);
+    break;
+  case 16:
+    __fastpackwithoutmask16(in, out);
+    break;
+  case 17:
+    __fastpackwithoutmask17(in, out);
+    break;
+  case 18:
+    __fastpackwithoutmask18(in, out);
+    break;
+  case 19:
+    __fastpackwithoutmask19(in, out);
+    break;
+  case 20:
+    __fastpackwithoutmask20(in, out);
+    break;
+  case 21:
+    __fastpackwithoutmask21(in, out);
+    break;
+  case 22:
+    __fastpackwithoutmask22(in, out);
+    break;
+  case 23:
+    __fastpackwithoutmask23(in, out);
+    break;
+  case 24:
+    __fastpackwithoutmask24(in, out);
+    break;
+  case 25:
+    __fastpackwithoutmask25(in, out);
+    break;
+  case 26:
+    __fastpackwithoutmask26(in, out);
+    break;
+  case 27:
+    __fastpackwithoutmask27(in, out);
+    break;
+  case 28:
+    __fastpackwithoutmask28(in, out);
+    break;
+  case 29:
+    __fastpackwithoutmask29(in, out);
+    break;
+  case 30:
+    __fastpackwithoutmask30(in, out);
+    break;
+  case 31:
+    __fastpackwithoutmask31(in, out);
+    break;
+  case 32:
+    __fastpackwithoutmask32(in, out);
+    break;
+  case 33:
+    __fastpackwithoutmask33(in, out);
+    break;
+  case 34:
+    __fastpackwithoutmask34(in, out);
+    break;
+  case 35:
+    __fastpackwithoutmask35(in, out);
+    break;
+  case 36:
+    __fastpackwithoutmask36(in, out);
+    break;
+  case 37:
+    __fastpackwithoutmask37(in, out);
+    break;
+  case 38:
+    __fastpackwithoutmask38(in, out);
+    break;
+  case 39:
+    __fastpackwithoutmask39(in, out);
+    break;
+  case 40:
+    __fastpackwithoutmask40(in, out);
+    break;
+  case 41:
+    __fastpackwithoutmask41(in, out);
+    break;
+  case 42:
+    __fastpackwithoutmask42(in, out);
+    break;
+  case 43:
+    __fastpackwithoutmask43(in, out);
+    break;
+  case 44:
+    __fastpackwithoutmask44(in, out);
+    break;
+  case 45:
+    __fastpackwithoutmask45(in, out);
+    break;
+  case 46:
+    __fastpackwithoutmask46(in, out);
+    break;
+  case 47:
+    __fastpackwithoutmask47(in, out);
+    break;
+  case 48:
+    __fastpackwithoutmask48(in, out);
+    break;
+  case 49:
+    __fastpackwithoutmask49(in, out);
+    break;
+  case 50:
+    __fastpackwithoutmask50(in, out);
+    break;
+  case 51:
+    __fastpackwithoutmask51(in, out);
+    break;
+  case 52:
+    __fastpackwithoutmask52(in, out);
+    break;
+  case 53:
+    __fastpackwithoutmask53(in, out);
+    break;
+  case 54:
+    __fastpackwithoutmask54(in, out);
+    break;
+  case 55:
+    __fastpackwithoutmask55(in, out);
+    break;
+  case 56:
+    __fastpackwithoutmask56(in, out);
+    break;
+  case 57:
+    __fastpackwithoutmask57(in, out);
+    break;
+  case 58:
+    __fastpackwithoutmask58(in, out);
+    break;
+  case 59:
+    __fastpackwithoutmask59(in, out);
+    break;
+  case 60:
+    __fastpackwithoutmask60(in, out);
+    break;
+  case 61:
+    __fastpackwithoutmask61(in, out);
+    break;
+  case 62:
+    __fastpackwithoutmask62(in, out);
+    break;
+  case 63:
+    __fastpackwithoutmask63(in, out);
+    break;
+  case 64:
+    __fastpackwithoutmask64(in, out);
+    break;
+  default:
+    break;
+  }
+}
+
+template <uint32_t BlockSize, typename IntType = uint32_t>
+uint32_t *packblockup(const IntType * source, uint32_t *out,
                       const uint32_t bit) {
   for (uint32_t j = 0; j != BlockSize; j += 32) {
     fastpack(source + j, out, bit);
@@ -354,8 +967,8 @@ uint32_t *packblockup(const uint32_t *source, uint32_t *out,
   return out;
 }
 
-template <uint32_t BlockSize>
-const uint32_t *unpackblock(const uint32_t *source, uint32_t *out,
+template <uint32_t BlockSize, typename IntType = uint32_t>
+const uint32_t *unpackblock(const uint32_t *source, IntType *out,
                             const uint32_t bit) {
   for (uint32_t j = 0; j != BlockSize; j += 32) {
     fastunpack(source, out + j, bit);

--- a/headers/blockpacking.h
+++ b/headers/blockpacking.h
@@ -102,12 +102,15 @@ public:
 template <uint32_t MiniBlockSize>
 class FastBinaryPacking : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   static const uint32_t HowManyMiniBlocks = 4;
   static const uint32_t BlockSize = HowManyMiniBlocks * MiniBlockSize;
   static const uint32_t bits32 = 8; // 8 > gccbits(32);
 
   void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
     checkifdivisibleby(length, BlockSize);
     const uint32_t *const initout(out);
     *out++ = static_cast<uint32_t>(length);
@@ -136,7 +139,7 @@ public:
   }
 
   const uint32_t *decodeArray(const uint32_t *in, const size_t /*length*/,
-                              uint32_t *out, size_t &nvalue) {
+                              uint32_t *out, size_t &nvalue) override {
     const uint32_t actuallength = *in++;
     const uint32_t *const initout(out);
     uint32_t Bs[HowManyMiniBlocks];
@@ -164,7 +167,7 @@ public:
     return in;
   }
 
-  std::string name() const {
+  std::string name() const override {
     std::ostringstream convert;
     convert << "FastBinaryPacking" << MiniBlockSize;
     return convert.str();
@@ -174,12 +177,15 @@ public:
 // A simpler version of FastBinaryPacking32. (For sanity testing.)
 class BP32 : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   static const uint32_t MiniBlockSize = 32;
   static const uint32_t HowManyMiniBlocks = 4;
   static const uint32_t BlockSize = HowManyMiniBlocks * MiniBlockSize;
 
   void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
     checkifdivisibleby(length, BlockSize);
     const uint32_t *const initout(out);
     *out++ = static_cast<uint32_t>(length);
@@ -198,7 +204,7 @@ public:
   }
 
   const uint32_t *decodeArray(const uint32_t *in, const size_t /*length*/,
-                              uint32_t *out, size_t &nvalue) {
+                              uint32_t *out, size_t &nvalue) override {
     const uint32_t actuallength = *in++;
     const uint32_t *const initout(out);
     uint32_t Bs[HowManyMiniBlocks];
@@ -217,7 +223,7 @@ public:
     return in;
   }
 
-  std::string name() const { return "BP32"; }
+  std::string name() const override { return "BP32"; }
 };
 
 /**

--- a/headers/codecs.h
+++ b/headers/codecs.h
@@ -18,9 +18,7 @@ class NotEnoughStorage : public std::runtime_error {
 public:
   size_t required; // number of 32-bit symbols required
   NotEnoughStorage(const size_t req)
-      : runtime_error(""), required(req){
-
-                           };
+      : runtime_error(""), required(req) {}
 };
 
 class IntegerCODEC {
@@ -38,6 +36,10 @@ public:
   virtual void encodeArray(const uint32_t *in, const size_t length,
                            uint32_t *out, size_t &nvalue) = 0;
 
+  virtual void encodeArray(const uint64_t *in, const size_t length,
+                           uint32_t *out, size_t &nvalue) {
+    throw std::logic_error("Not implemented!");
+  }
   /**
    * Usage is similar to decodeArray except that it returns a pointer
    * incremented from in. In theory it should be in+length. If the
@@ -54,6 +56,12 @@ public:
    */
   virtual const uint32_t *decodeArray(const uint32_t *in, const size_t length,
                                       uint32_t *out, size_t &nvalue) = 0;
+
+  virtual const uint32_t *decodeArray(const uint32_t *in, const size_t length,
+                                      uint64_t *out, size_t &nvalue) {
+    throw std::logic_error("Not implemented!");
+  }
+
   virtual ~IntegerCODEC() {}
 
   /**

--- a/headers/compositecodec.h
+++ b/headers/compositecodec.h
@@ -7,9 +7,9 @@
 #ifndef COMPOSITECODEC_H_
 #define COMPOSITECODEC_H_
 
+#include "codecs.h"
 #include "common.h"
 #include "util.h"
-#include "codecs.h"
 
 namespace FastPForLib {
 
@@ -19,18 +19,53 @@ namespace FastPForLib {
  */
 template <class Codec1, class Codec2>
 class CompositeCodec : public IntegerCODEC {
-public:
+ public:
   CompositeCodec() : codec1(), codec2() {}
   Codec1 codec1;
   Codec2 codec2;
+
   void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
+    _encodeArray<uint32_t>(in, length, out, nvalue);
+  }
+
+  void encodeArray(const uint64_t *in, const size_t length, uint32_t *out,
+                   size_t &nvalue) override {
+    _encodeArray<uint64_t>(in, length, out, nvalue);
+  }
+
+  const uint32_t *decodeArray(const uint32_t *in, const size_t length,
+                              uint32_t *out, size_t &nvalue) override {
+    return _decodeArray<uint32_t>(in, length, out, nvalue);
+  }
+
+  const uint32_t *decodeArray(const uint32_t *in, const size_t length,
+                              uint64_t *out, size_t &nvalue) override {
+    return _decodeArray<uint64_t>(in, length, out, nvalue);
+  }
+
+  std::string name() const override {
+    std::ostringstream convert;
+    convert << codec1.name() << "+" << codec2.name();
+    return convert.str();
+  }
+
+ private:
+  template <typename IntType>
+  void _encodeArray(const IntType *in, const size_t length, uint32_t *out,
+                    size_t &nvalue) {
+    if (nvalue == 0) {
+      return;
+    }
     const size_t roundedlength = length / Codec1::BlockSize * Codec1::BlockSize;
     size_t nvalue1 = nvalue;
     codec1.encodeArray(in, roundedlength, out, nvalue1);
 
     if (roundedlength < length) {
-      ASSERT(nvalue >= nvalue1, nvalue << " " << nvalue1);
+      if (nvalue1 > nvalue) {
+        throw std::logic_error(
+            "Encode run over output buffer. Potential buffer overflow!");
+      }
       size_t nvalue2 = nvalue - nvalue1;
       codec2.encodeArray(in + roundedlength, length - roundedlength,
                          out + nvalue1, nvalue2);
@@ -39,33 +74,39 @@ public:
       nvalue = nvalue1;
     }
   }
-  const uint32_t *decodeArray(const uint32_t *in, const size_t length,
-                              uint32_t *out, size_t &nvalue) {
-#ifndef NDEBUG
+
+  template <typename IntType>
+  const uint32_t *_decodeArray(const uint32_t *in, const size_t length,
+                               IntType *out, size_t &nvalue) {
+    if (nvalue == 0) {
+      return in;
+    }
     const uint32_t *const initin(in);
-#endif
     size_t mynvalue1 = nvalue;
     const uint32_t *in2 = codec1.decodeArray(in, length, out, mynvalue1);
     if (length + in > in2) {
-      assert(nvalue > mynvalue1);
+      if (nvalue <= mynvalue1) {
+        throw std::logic_error("Buffer contains more data than requested!");
+      }
       size_t nvalue2 = nvalue - mynvalue1;
       const uint32_t *in3 = codec2.decodeArray(in2, length - (in2 - in),
                                                out + mynvalue1, nvalue2);
       nvalue = mynvalue1 + nvalue2;
-      assert(initin + length >= in3);
+      if (initin + length < in3) {
+        throw std::logic_error(
+            "Decode run over output buffer. Potential buffer overflow!");
+      }
       return in3;
     }
     nvalue = mynvalue1;
-    assert(initin + length >= in2);
+    if (initin + length < in2) {
+      throw std::logic_error(
+          "Decode run over output buffer. Potential buffer overflow!");
+    }
     return in2;
-  }
-  std::string name() const {
-    std::ostringstream convert;
-    convert << codec1.name() << "+" << codec2.name();
-    return convert.str();
   }
 };
 
-} // namespace FastPFor
+}  // namespace FastPForLib
 
 #endif /* COMPOSITECODEC_H_ */

--- a/headers/fastpfor.h
+++ b/headers/fastpfor.h
@@ -138,8 +138,8 @@ class FastPForImpl {
 
   void getBestBFromData(const IntType *in, uint8_t &bestb, uint8_t &bestcexcept,
                         uint8_t &maxb) {
-    constexpr uint8_t bits = sizeof(IntType) * 8;
-    uint32_t freqs[bits + 1];
+    uint8_t bits = sizeof(IntType) * 8;
+    uint32_t freqs[65];
     for (uint32_t k = 0; k <= bits; ++k) freqs[k] = 0;
     for (uint32_t k = 0; k < BlockSize; ++k) {
       freqs[asmbits(in[k])]++;

--- a/headers/fastpfor.h
+++ b/headers/fastpfor.h
@@ -7,11 +7,11 @@
 
 #ifndef EPFOR_H_
 #define EPFOR_H_
-#include "common.h"
-#include "codecs.h"
-#include "packingvectors.h"
-#include "cpubenchmark.h"
 #include "blockpacking.h"
+#include "codecs.h"
+#include "common.h"
+#include "cpubenchmark.h"
+#include "packingvectors.h"
 #include "simple8b.h"
 
 namespace FastPForLib {
@@ -33,15 +33,19 @@ namespace FastPForLib {
  *
  */
 template <uint32_t BlockSizeInUnitsOfPackSize =
-              8> // BlockSizeInUnitsOfPackSize can have value 4 or 8
-class FastPFor : public IntegerCODEC {
-public:
+              8, /* BlockSizeInUnitsOfPackSize can have value 4 or 8 */
+          typename IntType =
+              uint32_t /* Integer type, currently support uint32_t or uint64_t */>
+class FastPForImpl {
+ public:
   /**
    * ps (page size) should be a multiple of BlockSize, any "large"
    * value should do.
    */
-  FastPFor(uint32_t ps = 65536)
-      : PageSize(ps), bitsPageSize(gccbits(PageSize)), datatobepacked(33),
+  FastPForImpl(uint32_t ps = 65536)
+      : PageSize(ps),
+        bitsPageSize(gccbits(PageSize)),
+        datatobepacked(sizeof(IntType) * 8 + 1),
         bytescontainer(PageSize + 3 * PageSize / BlockSize) {
     assert(ps / BlockSize * BlockSize == ps);
     assert(gccbits(BlockSizeInUnitsOfPackSize * PACKSIZE - 1) <= 8);
@@ -57,31 +61,24 @@ public:
   // sometimes, mem. usage can grow too much, this clears it up
   void resetBuffer() {
     for (size_t i = 0; i < datatobepacked.size(); ++i) {
-      std::vector<uint32_t>().swap(datatobepacked[i]);
+      std::vector<IntType>().swap(datatobepacked[i]);
     }
   }
 
   const uint32_t PageSize;
   const uint32_t bitsPageSize;
 
-  std::vector<std::vector<uint32_t>> datatobepacked;
+  std::vector<std::vector<IntType>> datatobepacked;
   std::vector<uint8_t> bytescontainer;
 
-#ifndef NDEBUG
   const uint32_t *decodeArray(const uint32_t *in, const size_t length,
-#else
-  const uint32_t *decodeArray(const uint32_t *in, const size_t,
-#endif
-                              uint32_t *out, size_t &nvalue) {
-#ifndef NDEBUG
+                              IntType *out, size_t &nvalue) {
     const uint32_t *const initin(in);
-#endif
     const size_t mynvalue = *in;
     ++in;
-    if (mynvalue > nvalue)
-      throw NotEnoughStorage(mynvalue);
+    if (mynvalue > nvalue) throw NotEnoughStorage(mynvalue);
     nvalue = mynvalue;
-    const uint32_t *const finalout(out + nvalue);
+    const IntType *const finalout(out + nvalue);
     while (out != finalout) {
       size_t thisnvalue(0);
       size_t thissize = static_cast<size_t>(
@@ -91,8 +88,13 @@ public:
       in += thisnvalue;
       out += thissize;
     }
-    assert(initin + length >= in);
-    resetBuffer(); // if you don't do this, the codec has a "memory".
+
+    if (initin + length < in) {
+      throw std::logic_error(
+          "Decode run over output buffer. Potential buffer overflow!");
+    }
+
+    resetBuffer();  // if you don't do this, the codec has a "memory".
     return in;
   }
 
@@ -101,13 +103,10 @@ public:
    * BlockSizeInUnitsOfPackSize * PACKSIZE. (This was done
    * to simplify slightly the implementation.)
    */
-  void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
+  void encodeArray(const IntType *in, const size_t length, uint32_t *out,
                    size_t &nvalue) {
     checkifdivisibleby(length, BlockSize);
-#ifndef NDEBUG
-    const uint32_t *const initout(out);
-#endif
-    const uint32_t *const finalin(in + length);
+    const IntType *const finalin(in + length);
 
     *out++ = static_cast<uint32_t>(length);
     const size_t oldnvalue = nvalue;
@@ -121,41 +120,42 @@ public:
       out += thisnvalue;
       in += thissize;
     }
-    assert(out == nvalue + initout);
-		if (oldnvalue < nvalue)
-			std::cerr
-					<< "It is possible we have a buffer overrun. You reported having allocated "
-					<< oldnvalue * sizeof(uint32_t)
-					<< " bytes for the compressed data but we needed "
-					<< nvalue * sizeof(uint32_t)
-					<< " bytes. Please increase the available memory"
-							" for compressed data or check the value of the last parameter provided "
-							" to the encodeArray method." << std::endl;
-    resetBuffer(); // if you don't do this, the buffer has a memory
+    if (oldnvalue < nvalue) {
+      std::ostringstream os;
+      os << "It is possible we have a buffer overrun. You reported having "
+            "allocated "
+         << oldnvalue * sizeof(uint32_t)
+         << " bytes for the compressed data but we needed "
+         << nvalue * sizeof(uint32_t)
+         << " bytes. Please increase the available memory"
+            " for compressed data or check the value of the last parameter "
+            "provided "
+            " to the encodeArray method.";
+      throw std::logic_error(os.str());
+    }
+    resetBuffer();  // if you don't do this, the buffer has a memory
   }
 
-  void getBestBFromData(const uint32_t *in, uint8_t &bestb,
-                        uint8_t &bestcexcept, uint8_t &maxb) {
-    uint32_t freqs[33];
-    for (uint32_t k = 0; k <= 32; ++k)
-      freqs[k] = 0;
+  void getBestBFromData(const IntType *in, uint8_t &bestb, uint8_t &bestcexcept,
+                        uint8_t &maxb) {
+    constexpr uint8_t bits = sizeof(IntType) * 8;
+    uint32_t freqs[bits + 1];
+    for (uint32_t k = 0; k <= bits; ++k) freqs[k] = 0;
     for (uint32_t k = 0; k < BlockSize; ++k) {
       freqs[asmbits(in[k])]++;
     }
-    bestb = 32;
-    while (freqs[bestb] == 0)
-      bestb--;
+    bestb = bits;
+    while (freqs[bestb] == 0) bestb--;
     maxb = bestb;
     uint32_t bestcost = bestb * BlockSize;
     uint32_t cexcept = 0;
     bestcexcept = static_cast<uint8_t>(cexcept);
-    for (uint32_t b = bestb - 1; b < 32; --b) {
+    for (uint32_t b = bestb - 1; b < bits; --b) {
       cexcept += freqs[b + 1];
       uint32_t thiscost = cexcept * overheadofeachexcept +
                           cexcept * (maxb - b) + b * BlockSize +
-                          8; // the  extra 8 is the cost of storing maxbits
-      if (maxb - b == 1)
-        thiscost -= cexcept;
+                          8;  // the  extra 8 is the cost of storing maxbits
+      if (maxb - b == 1) thiscost -= cexcept;
       if (thiscost < bestcost) {
         bestcost = thiscost;
         bestb = static_cast<uint8_t>(b);
@@ -164,15 +164,16 @@ public:
     }
   }
 
-  void __encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
+  void __encodeArray(const IntType *in, const size_t length, uint32_t *out,
                      size_t &nvalue) {
-    uint32_t *const initout = out; // keep track of this
+    uint32_t *const initout = out;  // keep track of this
     checkifdivisibleby(length, BlockSize);
-    uint32_t *const headerout = out++; // keep track of this
-    for (uint32_t k = 0; k < 32 + 1; ++k)
+    uint32_t *const headerout = out++;  // keep track of this
+    for (uint32_t k = 0; k < sizeof(IntType) * 8 + 1; ++k) {
       datatobepacked[k].clear();
+    }
     uint8_t *bc = &bytescontainer[0];
-    for (const uint32_t *const final = in + length; (in + BlockSize <= final);
+    for (const IntType *const final = in + length; (in + BlockSize <= final);
          in += BlockSize) {
       uint8_t bestb, bestcexcept, maxb;
       getBestBFromData(in, bestb, bestcexcept, maxb);
@@ -180,7 +181,7 @@ public:
       *bc++ = bestcexcept;
       if (bestcexcept > 0) {
         *bc++ = maxb;
-        std::vector<uint32_t> &thisexceptioncontainer =
+        std::vector<IntType> &thisexceptioncontainer =
             datatobepacked[maxb - bestb];
         const uint32_t maxval = 1U << bestb;
         for (uint32_t k = 0; k < BlockSize; ++k) {
@@ -199,22 +200,26 @@ public:
     *(out++) = bytescontainersize;
     memcpy(out, &bytescontainer[0], bytescontainersize);
     out += (bytescontainersize + sizeof(uint32_t) - 1) / sizeof(uint32_t);
-    uint32_t bitmap = 0;
-    for (uint32_t k = 2; k <= 32; ++k) {
-      if (datatobepacked[k].size() != 0)
-        bitmap |= (1U << (k - 1));
+
+    IntType bitmap = 0;
+    for (uint32_t k = 2; k <= sizeof(IntType) * 8; ++k) {
+      if (datatobepacked[k].size() != 0) bitmap |= (1UL << (k - 1));
     }
-    *(out++) = bitmap;
-    for (uint32_t k = 2; k <= 32; ++k) {
+    *(reinterpret_cast<IntType *>(out)) = bitmap;
+    out += (sizeof(IntType) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+
+    for (uint32_t k = 2; k <= sizeof(IntType) * 8; ++k) {
       if (datatobepacked[k].size() > 0) {
-        out = packingvector<32>::packmeuptightwithoutmask(datatobepacked[k],
-                                                          out, k);
+        size_t nValue = datatobepacked[k].size();
+        datatobepacked[k].resize((datatobepacked[k].size() + 32 - 1) / 32 * 32);
+        out = packingvector<32>::packmeuptightwithoutmask(
+            datatobepacked[k].data(), nValue, out, k);
       }
     }
     nvalue = out - initout;
   }
 
-  void __decodeArray(const uint32_t *in, size_t &length, uint32_t *out,
+  void __decodeArray(const uint32_t *in, size_t &length, IntType *out,
                      const size_t nvalue) {
     const uint32_t *const initin = in;
     const uint32_t *const headerin = in++;
@@ -223,16 +228,21 @@ public:
     const uint32_t bytesize = *inexcept++;
     const uint8_t *bytep = reinterpret_cast<const uint8_t *>(inexcept);
     inexcept += (bytesize + sizeof(uint32_t) - 1) / sizeof(uint32_t);
-    const uint32_t bitmap = *(inexcept++);
-    for (uint32_t k = 2; k <= 32; ++k) {
-      if ((bitmap & (1U << (k - 1))) != 0) {
-        inexcept =
-            packingvector<32>::unpackmetight(inexcept, datatobepacked[k], k);
+    IntType bitmap = *(reinterpret_cast<const IntType *>(inexcept));
+    inexcept += (sizeof(IntType) + sizeof(uint32_t) - 1) / sizeof(uint32_t);
+    for (uint32_t k = 2; k <= sizeof(IntType) * 8; ++k) {
+      if ((bitmap & (1UL << (k - 1))) != 0) {
+        uint32_t nvalue = *inexcept;
+        datatobepacked[k].resize((nvalue + PACKSIZE - 1) / PACKSIZE * PACKSIZE);
+        inexcept = packingvector<32>::unpackmetight(
+            inexcept, datatobepacked[k].data(), datatobepacked[k].size(), k);
+        datatobepacked[k].resize(nvalue);
       }
     }
     length = inexcept - initin;
-    std::vector<uint32_t>::const_iterator unpackpointers[32 + 1];
-    for (uint32_t k = 1; k <= 32; ++k) {
+    typename std::vector<IntType>::const_iterator
+        unpackpointers[sizeof(IntType) * 8 + 1];
+    for (uint32_t k = 1; k <= sizeof(IntType) * 8; ++k) {
       unpackpointers[k] = datatobepacked[k].begin();
     }
     for (uint32_t run = 0; run < nvalue / BlockSize; ++run, out += BlockSize) {
@@ -244,24 +254,62 @@ public:
         if (maxbits - b == 1) {
           for (uint32_t k = 0; k < cexcept; ++k) {
             const uint8_t pos = *(bytep++);
-            out[pos] |= static_cast<uint32_t>(1) << b;
+            out[pos] |= static_cast<uint64_t>(1) << b;
           }
         } else {
-          std::vector<uint32_t>::const_iterator &exceptionsptr =
+          typename std::vector<IntType>::const_iterator &exceptionsptr =
               unpackpointers[maxbits - b];
           for (uint32_t k = 0; k < cexcept; ++k) {
             const uint8_t pos = *(bytep++);
-            out[pos] |= (*(exceptionsptr++)) << b;
+            out[pos] |= (static_cast<uint64_t>(*(exceptionsptr++))) << b;
           }
         }
       }
     }
     assert(in == headerin + wheremeta);
   }
+};
 
-  std::string name() const {
+template <uint32_t BlockSizeInUnitsOfPackSize = 8>
+class FastPFor : public IntegerCODEC {
+ public:
+  FastPFor(uint32_t pageSize = 65536) : pfor32(pageSize) {}
+
+  enum {
+    PACKSIZE = 32,
+    overheadofeachexcept = 8,
+    overheadduetobits = 8,
+    overheadduetonmbrexcept = 8,
+    BlockSize = BlockSizeInUnitsOfPackSize * PACKSIZE
+  };
+
+  void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
+                   size_t &nvalue) override {
+    pfor32.encodeArray(in, length, out, nvalue);
+  }
+
+  void encodeArray(const uint64_t *in, const size_t length, uint32_t *out,
+                   size_t &nvalue) override {
+    pfor64.encodeArray(in, length, out, nvalue);
+  }
+
+  const uint32_t *decodeArray(const uint32_t *in, const size_t length,
+                              uint32_t *out, size_t &nvalue) override {
+    return pfor32.decodeArray(in, length, out, nvalue);
+  }
+
+  const uint32_t *decodeArray(const uint32_t *in, const size_t length,
+                              uint64_t *out, size_t &nvalue) override {
+    return pfor64.decodeArray(in, length, out, nvalue);
+  }
+
+  std::string name() const override {
     return std::string("FastPFor") + std::to_string(BlockSize);
   }
+
+ private:
+  FastPForImpl<BlockSizeInUnitsOfPackSize, uint32_t> pfor32;
+  FastPForImpl<BlockSizeInUnitsOfPackSize, uint64_t> pfor64;
 };
 
 /**
@@ -280,6 +328,9 @@ public:
 template <class EXCEPTIONCODER = Simple8b<true>>
 class SimplePFor : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   EXCEPTIONCODER ecoder;
   /**
    * ps (page size) should be a multiple of BlockSize, any "large"
@@ -308,7 +359,7 @@ public:
   std::vector<uint8_t> bytescontainer;
 
   const uint32_t *decodeArray(const uint32_t *in, const size_t length,
-                              uint32_t *out, size_t &nvalue) {
+                              uint32_t *out, size_t &nvalue) override {
     const uint32_t *const initin(in);
     const size_t mynvalue = *in;
     ++in;
@@ -335,7 +386,7 @@ public:
    * to simplify slightly the implementation.)
    */
   void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
     checkifdivisibleby(length, BlockSize);
     const uint32_t *const initout(out);
     const uint32_t *const finalin(in + length);
@@ -353,15 +404,15 @@ public:
       in += thissize;
     }
     assert(out == nvalue + initout);
-		if (oldnvalue < nvalue)
-			std::cerr
-					<< "It is possible we have a buffer overrun. You reported having allocated "
-					<< oldnvalue * sizeof(uint32_t)
-					<< " bytes for the compressed data but we needed "
-					<< nvalue * sizeof(uint32_t)
-					<< " bytes. Please increase the available memory"
-							" for compressed data or check the value of the last parameter provided "
-							" to the encodeArray method." << std::endl;
+    if (oldnvalue < nvalue)
+      std::cerr
+          << "It is possible we have a buffer overrun. You reported having allocated "
+          << oldnvalue * sizeof(uint32_t)
+          << " bytes for the compressed data but we needed "
+          << nvalue * sizeof(uint32_t)
+          << " bytes. Please increase the available memory"
+              " for compressed data or check the value of the last parameter provided "
+              " to the encodeArray method." << std::endl;
   }
 
   void getBestBFromData(const uint32_t *in, uint8_t &bestb,
@@ -458,9 +509,9 @@ public:
     assert(in == headerin + wheremeta);
   }
 
-  std::string name() const { return "SimplePFor"; }
+  std::string name() const override { return "SimplePFor"; }
 };
 
-} // namespace FastPFor
+}  // namespace FastPForLib
 
 #endif /* EPFOR_H_ */

--- a/headers/newpfor.h
+++ b/headers/newpfor.h
@@ -36,6 +36,9 @@ template <uint32_t BlockSizeInUnitsOfPackSize,
           class ExceptionCoder = Simple16<false>>
 class NewPFor : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   enum {
     PFORDELTA_B = 6,
     PFORDELTA_NEXCEPT = 10,

--- a/headers/packingvectors.h
+++ b/headers/packingvectors.h
@@ -29,27 +29,28 @@ public:
     return in;
   }
 
-  template <class STLContainer>
-  static const uint32_t *unpackmetight(const uint32_t *in, STLContainer &out,
+  template <typename IntType>
+  static const uint32_t *unpackmetight(
+                                       const uint32_t *in,
+                                       IntType * out,
+                                       size_t outSize,
                                        const uint32_t bit) {
     const uint32_t size = *in;
     ++in;
-    out.resize((size + PACKSIZE - 1) / PACKSIZE * PACKSIZE);
     uint32_t j = 0;
     for (; j + PACKSIZE - 1 < size; j += PACKSIZE) {
       fastunpack(in, &out[j], bit);
       in += bit;
     }
-    uint32_t buffer[PACKSIZE];
+    uint32_t buffer[PACKSIZE * 2];
     uint32_t remaining = size - j;
     memcpy(buffer, in, (remaining * bit + 31) / 32 * sizeof(uint32_t));
     uint32_t *bpointer = buffer;
-    in += (out.size() - j) / PACKSIZE * bit;
-    for (; j != out.size(); j += PACKSIZE) {
+    in += (outSize - j) / PACKSIZE * bit;
+    for (; j != outSize; j += PACKSIZE) {
       fastunpack(bpointer, &out[j], bit);
       bpointer += bit;
     }
-    out.resize(size);
     in -= (j - size) * bit / 32;
     return in;
   }
@@ -88,22 +89,20 @@ public:
     return out;
   }
 
-  template <class STLContainer>
-  static uint32_t *packmeuptightwithoutmask(STLContainer &source, uint32_t *out,
+  template <typename IntType>
+  static uint32_t *packmeuptightwithoutmask(
+                                            const IntType * source,
+                                            size_t size,
+                                            uint32_t *out,
                                             const uint32_t bit) {
-    const size_t size = source.size();
     *out = static_cast<uint32_t>(size);
     out++;
-    if (source.size() == 0)
-      return out;
-    source.resize((source.size() + PACKSIZE - 1) / PACKSIZE * PACKSIZE);
     uint32_t j = 0;
-    for (; j != source.size(); j += PACKSIZE) {
+    for (; j < size; j += PACKSIZE) {
       fastpackwithoutmask(&source[j], out, bit);
       out += bit;
     }
     out -= (j - size) * bit / 32;
-    source.resize(size);
     return out;
   }
 };

--- a/headers/pfor.h
+++ b/headers/pfor.h
@@ -41,6 +41,9 @@ namespace FastPForLib {
  */
 class PFor : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   enum {
     BlockSizeInUnitsOfPackSize = 4,
     PACKSIZE = 32,

--- a/headers/pfor2008.h
+++ b/headers/pfor2008.h
@@ -35,6 +35,9 @@ namespace FastPForLib {
  */
 class PFor2008 : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   enum {
     BlockSizeInUnitsOfPackSize = 4,
     PACKSIZE = 32,
@@ -167,7 +170,7 @@ public:
   }
 
   void encodeArray(const uint32_t *in, const size_t len, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
     *out++ = static_cast<uint32_t>(len);
 #ifndef NDEBUG
     const uint32_t *const finalin(in + len);
@@ -192,7 +195,7 @@ public:
     nvalue = totalnvalue;
   }
   const uint32_t *decodeArray(const uint32_t *in, const size_t len,
-                              uint32_t *out, size_t &nvalue) {
+                              uint32_t *out, size_t &nvalue) override {
     nvalue = *in++;
     if (nvalue == 0)
       return in;
@@ -344,7 +347,7 @@ public:
     }
   }
 
-  virtual std::string name() const {
+  virtual std::string name() const override {
     std::ostringstream convert;
     convert << "PFor2008";
     return convert.str();

--- a/headers/simdbinarypacking.h
+++ b/headers/simdbinarypacking.h
@@ -29,6 +29,9 @@ namespace FastPForLib {
  */
 class SIMDBinaryPacking : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   static const uint32_t CookiePadder = 123456;
   static const uint32_t MiniBlockSize = 128;
   static const uint32_t HowManyMiniBlocks = 16;

--- a/headers/simdfastpfor.h
+++ b/headers/simdfastpfor.h
@@ -44,6 +44,9 @@ template <uint32_t BlockSizeInUnitsOfPackSize =
               8> // BlockSizeInUnitsOfPackSize can have value 4 or 8
 class SIMDFastPFor : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   /**
    * ps (page size) should be a multiple of BlockSize, any "large"
    * value should do.
@@ -152,7 +155,7 @@ public:
 #else
   const uint32_t *decodeArray(const uint32_t *in, const size_t,
 #endif
-                              uint32_t *out, size_t &nvalue) {
+                              uint32_t *out, size_t &nvalue) override {
 #ifndef NDEBUG
     const uint32_t *const initin(in);
 #endif
@@ -185,7 +188,7 @@ public:
    * to simplify slightly the implementation.)
    */
   void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
     checkifdivisibleby(length, BlockSize);
 #ifndef NDEBUG
     const uint32_t *const initout(out);
@@ -342,7 +345,7 @@ public:
     assert(in == headerin + wheremeta);
   }
 
-  std::string name() const {
+  std::string name() const override {
     return std::string("SIMDFastPFor") + std::to_string(BlockSize);
   }
 };
@@ -363,6 +366,9 @@ public:
 template <class EXCEPTIONCODER = Simple8b<true>>
 class SIMDSimplePFor : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   EXCEPTIONCODER ecoder;
   /**
    * ps (page size) should be a multiple of BlockSize, any "large"
@@ -391,7 +397,7 @@ public:
   std::vector<uint8_t> bytescontainer;
 
   const uint32_t *decodeArray(const uint32_t *in, const size_t length,
-                              uint32_t *out, size_t &nvalue) {
+                              uint32_t *out, size_t &nvalue) override {
     const uint32_t *const initin(in);
     const size_t mynvalue = *in;
     ++in;
@@ -418,7 +424,7 @@ public:
    * to simplify slightly the implementation.)
    */
   void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
     checkifdivisibleby(length, BlockSize);
     const uint32_t *const initout(out);
     const uint32_t *const finalin(in + length);
@@ -547,7 +553,7 @@ public:
     assert(in == headerin + wheremeta);
   }
 
-  std::string name() const { return "SIMDSimplePFor"; }
+  std::string name() const override { return "SIMDSimplePFor"; }
 };
 
 } // namespace FastPFor

--- a/headers/simdgroupsimple.h
+++ b/headers/simdgroupsimple.h
@@ -17,17 +17,17 @@ namespace FastPForLib {
 /**
  * This is an implementation of the compression algorithm SIMD-GroupSimple,
  * which was proposed in Section 4 of the following paper:
- * 
+ *
  * W. X. Zhao, X. Zhang, D. Lemire, D. Shan, J. Nie, H. Yan, and J. Wen.
  * A general simd-based approach to accelerating compression algorithms.
  * ACM Trans. Inf. Syst., 33(3), 2015.
  * http://arxiv.org/abs/1502.01916
- * 
+ *
  * Implemented by Patrick Damme,
- * https://wwwdb.inf.tu-dresden.de/our-group/team/patrick-damme . 
- * 
+ * https://wwwdb.inf.tu-dresden.de/our-group/team/patrick-damme .
+ *
  * We provide two variants of the compression part of the algorithm.
- * 
+ *
  * The original variant
  * ====================
  * The first variant closely follows the original algorithm as described in the
@@ -38,27 +38,27 @@ namespace FastPForLib {
  * However, our implementation differs from the paper in some minor points, for
  * instance, we directly look up the mask used in the pattern selection
  * algorithm instead of calculating it from a looked up bit width.
- * 
+ *
  * The variant using a quad max ring buffer
  * ========================================
  * The second variant is based on the original description, but uses a ring
  * buffer instead of an array for the (pseudo) quad max values to reduce the
  * size of the temporary data during the compression. More details on this can
  * be found in Section 3.2.3 of the following paper:
- * 
+ *
  * P. Damme, D. Habich, J. Hildebrandt, and W. Lehner. Lightweight data
  * compression algorithms: An experimental survey (experiments and analyses).
  * In Proceedings of the 20th International Conference on Extending Database
  * Technology, EDBT 2017.
  * http://openproceedings.org/2017/conf/edbt/paper-146.pdf
- * 
+ *
  * The template parameter useRingBuf determines which variant is used:
  * - false: original variant
  * - true: the variant with the ring buffer
  * Both variants use the same packing routines and the same decompression
  * algorithm. Our experiments suggest that the variant with the ring buffer is
  * faster than the original algorithm for small bit widths.
- * 
+ *
  * Compressed data format
  * ======================
  * As described in the original paper, the compressed data consists of two
@@ -92,7 +92,7 @@ namespace FastPForLib {
  * To sum up: For maximum performance use SIMDGroupSimple<false, false> or
  * SIMDGroupSimple<true, true>; to verify that the two variants really produce
  * the same data, use the same value for pessimisticGap.
- * 
+ *
  * Further assumptions
  * ===================
  * Finally, this implementation assumes that the number of 32-bit integers to
@@ -102,6 +102,9 @@ namespace FastPForLib {
 template<bool useRingBuf, bool pessimisticGap>
 class SIMDGroupSimple : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   // Tell CompositeCodec that this implementation can only handle input sizes
   // which are multiples of four.
   static const uint32_t BlockSize = 4;
@@ -344,7 +347,7 @@ public:
    * function is called at most once per array to decompress. Hence, top
    * efficiency is not that crucial here.
    */
-  inline static void decomprIncompleteBlock(const uint8_t &n, 
+  inline static void decomprIncompleteBlock(const uint8_t &n,
                                             const __m128i *&in,
                                             __m128i *&out) {
     // We choose the bit width consistent with comprIncompleteBlock().
@@ -816,7 +819,7 @@ public:
     checkifdivisibleby(len, BlockSize);
     if (needPaddingTo128Bits(in))
       throw std::runtime_error("the input buffer must be aligned to 16 bytes");
-    
+
     if (useRingBuf)
       encodeArrayInternal_wRingBuf(in, len, out, nvalue);
     else
@@ -827,7 +830,7 @@ public:
                               uint32_t *out, size_t &nvalue) {
     if (needPaddingTo128Bits(out))
       throw std::runtime_error("the output buffer must be aligned to 16 bytes");
-    
+
     // The start of the header.
     const uint32_t *const inHeader32 = in;
     nvalue = inHeader32[0];

--- a/headers/simdnewpfor.h
+++ b/headers/simdnewpfor.h
@@ -45,6 +45,9 @@ template <uint32_t BlockSizeInUnitsOfPackSize,
           class ExceptionCoder = Simple16<false>>
 class SIMDNewPFor : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   enum {
     PFORDELTA_B = 6,
     PFORDELTA_NEXCEPT = 10,

--- a/headers/simdpfor.h
+++ b/headers/simdpfor.h
@@ -40,6 +40,9 @@ namespace FastPForLib {
  */
 class SIMDPFor : public IntegerCODEC {
 public:
+  using IntegerCODEC::encodeArray;
+  using IntegerCODEC::decodeArray;
+
   enum {
     BlockSizeInUnitsOfPackSize = 4,
     PACKSIZE = 32,
@@ -167,7 +170,7 @@ public:
   }
 
   void encodeArray(const uint32_t *in, const size_t len, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
     *out++ = static_cast<uint32_t>(len);
 #ifndef NDEBUG
     const uint32_t *const finalin(in + len);
@@ -192,7 +195,7 @@ public:
     nvalue = totalnvalue;
   }
   const uint32_t *decodeArray(const uint32_t *in, const size_t len,
-                              uint32_t *out, size_t &nvalue) {
+                              uint32_t *out, size_t &nvalue) override {
     nvalue = *in++;
     if (nvalue == 0)
       return in;
@@ -299,7 +302,7 @@ public:
     }
   }
 
-  virtual std::string name() const {
+  virtual std::string name() const override {
     std::ostringstream convert;
     convert << "SIMDPFor";
     return convert.str();

--- a/headers/util.h
+++ b/headers/util.h
@@ -173,6 +173,17 @@ __attribute__((const)) inline uint32_t asmbits(const uint32_t v) {
 #endif
 }
 
+__attribute__((const)) inline uint32_t asmbits(const uint64_t v) {
+#ifdef _MSC_VER
+  return gccbits(v);
+#else
+  if (v == 0) return 0;
+  uint64_t answer;
+  __asm__("bsr %1, %0;" : "=r"(answer) : "r"(v));
+  return static_cast<uint32_t>(answer + 1);
+#endif
+}
+
 __attribute__((const)) inline uint32_t slowbits(uint32_t v) {
   uint32_t r = 0;
   while (v) {

--- a/headers/variablebyte.h
+++ b/headers/variablebyte.h
@@ -7,23 +7,36 @@
 
 #ifndef VARIABLEBYTE_H_
 #define VARIABLEBYTE_H_
-#include "common.h"
 #include "codecs.h"
+#include "common.h"
 
 namespace FastPForLib {
 
 class VariableByte : public IntegerCODEC {
-public:
-  template <uint32_t i> uint8_t extract7bits(const uint32_t val) {
+ public:
+  template <uint32_t i>
+  uint8_t extract7bits(const uint64_t val) {
     return static_cast<uint8_t>((val >> (7 * i)) & ((1U << 7) - 1));
   }
 
-  template <uint32_t i> uint8_t extract7bitsmaskless(const uint32_t val) {
+  template <uint32_t i>
+  uint8_t extract7bitsmaskless(const uint64_t val) {
     return static_cast<uint8_t>((val >> (7 * i)));
   }
 
   void encodeArray(const uint32_t *in, const size_t length, uint32_t *out,
-                   size_t &nvalue) {
+                   size_t &nvalue) override {
+    _encodeArray<uint32_t>(in, length, out, nvalue);
+  }
+
+  void encodeArray(const uint64_t *in, const size_t length, uint32_t *out,
+                   size_t &nvalue) override {
+    _encodeArray<uint64_t>(in, length, out, nvalue);
+  }
+
+  template <typename T>
+  void _encodeArray(const T *in, const size_t length, uint32_t *out,
+                    size_t &nvalue) {
     uint8_t *bout = reinterpret_cast<uint8_t *>(out);
     const uint8_t *const initbout = reinterpret_cast<uint8_t *>(out);
     size_t bytenvalue = nvalue * sizeof(uint32_t);
@@ -37,38 +50,114 @@ public:
     nvalue = storageinbytes / 4;
   }
 
-  void encodeToByteArray(const uint32_t *in, const size_t length, uint8_t *bout,
+  template <typename T>
+  void encodeToByteArray(const T *in, const size_t length, uint8_t *bout,
                          size_t &nvalue) {
     const uint8_t *const initbout = bout;
     for (size_t k = 0; k < length; ++k) {
-      const uint32_t val = in[k];
+      const uint64_t val = in[k];
       /**
        * Code below could be shorter. Whether it could be faster
        * depends on your compiler and machine.
        */
-      if (val < (1U << 7)) {
-        *bout = static_cast<uint8_t>(val | (1U << 7));
+      if (val < (1UL << 7)) {
+        *bout = static_cast<uint8_t>(val | (1UL << 7));
         ++bout;
-      } else if (val < (1U << 14)) {
+      } else if (val < (1UL << 14)) {
         *bout = extract7bits<0>(val);
         ++bout;
-        *bout = extract7bitsmaskless<1>(val) | (1U << 7);
+        *bout = extract7bitsmaskless<1>(val) | (1UL << 7);
         ++bout;
-      } else if (val < (1U << 21)) {
+      } else if (val < (1UL << 21)) {
         *bout = extract7bits<0>(val);
         ++bout;
         *bout = extract7bits<1>(val);
         ++bout;
-        *bout = extract7bitsmaskless<2>(val) | (1U << 7);
+        *bout = extract7bitsmaskless<2>(val) | (1UL << 7);
         ++bout;
-      } else if (val < (1U << 28)) {
+      } else if (val < (1UL << 28)) {
         *bout = extract7bits<0>(val);
         ++bout;
         *bout = extract7bits<1>(val);
         ++bout;
         *bout = extract7bits<2>(val);
         ++bout;
-        *bout = extract7bitsmaskless<3>(val) | (1U << 7);
+        *bout = extract7bitsmaskless<3>(val) | (1UL << 7);
+        ++bout;
+      } else if (val < (1UL << 35)) {
+        *bout = extract7bits<0>(val);
+        ++bout;
+        *bout = extract7bits<1>(val);
+        ++bout;
+        *bout = extract7bits<2>(val);
+        ++bout;
+        *bout = extract7bits<3>(val);
+        ++bout;
+        *bout = extract7bitsmaskless<4>(val) | (1UL << 7);
+        ++bout;
+      } else if (val < (1UL << 42)) {
+        *bout = extract7bits<0>(val);
+        ++bout;
+        *bout = extract7bits<1>(val);
+        ++bout;
+        *bout = extract7bits<2>(val);
+        ++bout;
+        *bout = extract7bits<3>(val);
+        ++bout;
+        *bout = extract7bits<4>(val);
+        ++bout;
+        *bout = extract7bitsmaskless<5>(val) | (1UL << 7);
+        ++bout;
+      } else if (val < (1UL << 49)) {
+        *bout = extract7bits<0>(val);
+        ++bout;
+        *bout = extract7bits<1>(val);
+        ++bout;
+        *bout = extract7bits<2>(val);
+        ++bout;
+        *bout = extract7bits<3>(val);
+        ++bout;
+        *bout = extract7bits<4>(val);
+        ++bout;
+        *bout = extract7bits<5>(val);
+        ++bout;
+        *bout = extract7bitsmaskless<6>(val) | (1UL << 7);
+        ++bout;
+      } else if (val < (1UL << 56)) {
+        *bout = extract7bits<0>(val);
+        ++bout;
+        *bout = extract7bits<1>(val);
+        ++bout;
+        *bout = extract7bits<2>(val);
+        ++bout;
+        *bout = extract7bits<3>(val);
+        ++bout;
+        *bout = extract7bits<4>(val);
+        ++bout;
+        *bout = extract7bits<5>(val);
+        ++bout;
+        *bout = extract7bits<6>(val);
+        ++bout;
+        *bout = extract7bitsmaskless<7>(val) | (1UL << 7);
+        ++bout;
+      } else if (val < (1UL << 63)) {
+        *bout = extract7bits<0>(val);
+        ++bout;
+        *bout = extract7bits<1>(val);
+        ++bout;
+        *bout = extract7bits<2>(val);
+        ++bout;
+        *bout = extract7bits<3>(val);
+        ++bout;
+        *bout = extract7bits<4>(val);
+        ++bout;
+        *bout = extract7bits<5>(val);
+        ++bout;
+        *bout = extract7bits<6>(val);
+        ++bout;
+        *bout = extract7bits<7>(val);
+        ++bout;
+        *bout = extract7bitsmaskless<8>(val) | (1UL << 7);
         ++bout;
       } else {
         *bout = extract7bits<0>(val);
@@ -79,7 +168,17 @@ public:
         ++bout;
         *bout = extract7bits<3>(val);
         ++bout;
-        *bout = extract7bitsmaskless<4>(val) | (1U << 7);
+        *bout = extract7bits<4>(val);
+        ++bout;
+        *bout = extract7bits<5>(val);
+        ++bout;
+        *bout = extract7bits<6>(val);
+        ++bout;
+        *bout = extract7bits<7>(val);
+        ++bout;
+        *bout = extract7bits<8>(val);
+        ++bout;
+        *bout = extract7bitsmaskless<9>(val) | (1UL << 7);
         ++bout;
       }
     }
@@ -87,25 +186,33 @@ public:
   }
 
   const uint32_t *decodeArray(const uint32_t *in, const size_t length,
-                              uint32_t *out, size_t &nvalue) {
-    decodeFromByteArray((const uint8_t *)in, length * sizeof(uint32_t), out,
-                        nvalue);
+                              uint32_t *out, size_t &nvalue) override {
+    decodeFromByteArray<uint32_t>((const uint8_t *)in,
+                                  length * sizeof(uint32_t), out, nvalue);
     return in + length;
   }
 
+  const uint32_t *decodeArray(const uint32_t *in, const size_t length,
+                              uint64_t *out, size_t &nvalue) override {
+    decodeFromByteArray<uint64_t>((const uint8_t *)in,
+                                  length * sizeof(uint32_t), out, nvalue);
+    return in + length;
+  }
+
+  template <typename T>
   const uint8_t *decodeFromByteArray(const uint8_t *inbyte, const size_t length,
-                                     uint32_t *out, size_t &nvalue) {
+                                     T *out, size_t &nvalue) {
     if (length == 0) {
       nvalue = 0;
-      return inbyte; // abort
+      return inbyte;  // abort
     }
     const uint8_t *const endbyte = inbyte + length;
-    const uint32_t *const initout(out);
+    const T *const initout(out);
     // this assumes that there is a value to be read
 
-    while (endbyte > inbyte + 5) {
-      uint8_t c;
-      uint32_t v;
+    while (endbyte > inbyte + 10) {
+      uint64_t c;
+      T v = 0;
 
       c = inbyte[0];
       v = c & 0x7F;
@@ -140,14 +247,55 @@ public:
       }
 
       c = inbyte[4];
-      inbyte += 5;
-      v |= (c & 0x0F) << 28;
+      v |= (c & 0x7F) << 28;
+      if (c >= 128) {
+        inbyte += 5;
+        *out++ = v;
+        continue;
+      }
+
+      c = inbyte[5];
+      v |= static_cast<uint64_t>(c & 0x7F) << 35;
+      if (c >= 128) {
+        inbyte += 6;
+        *out++ = v;
+        continue;
+      }
+
+      c = inbyte[6];
+      v |= static_cast<uint64_t>(c & 0x7F) << 42;
+      if (c >= 128) {
+        inbyte += 7;
+        *out++ = v;
+        continue;
+      }
+
+      c = inbyte[7];
+      v |= static_cast<uint64_t>(c & 0x7F) << 49;
+      if (c >= 128) {
+        inbyte += 8;
+        *out++ = v;
+        continue;
+      }
+
+      c = inbyte[8];
+      v |= static_cast<uint64_t>(c & 0x7F) << 56;
+      if (c >= 128) {
+        inbyte += 9;
+        *out++ = v;
+        continue;
+      }
+
+      c = inbyte[9];
+      inbyte += 10;
+      v |= static_cast<uint64_t>(c & 0x1) << 63;
       *out++ = v;
     }
+
     while (endbyte > inbyte) {
       unsigned int shift = 0;
-      for (uint32_t v = 0; endbyte > inbyte; shift += 7) {
-        uint8_t c = *inbyte++;
+      for (T v = 0; endbyte > inbyte; shift += 7) {
+        uint64_t c = *inbyte++;
         v += ((c & 127) << shift);
         if ((c & 128)) {
           *out++ = v;
@@ -159,16 +307,18 @@ public:
     return inbyte;
   }
 
-  std::string name() const { return "VariableByte"; }
+  std::string name() const override { return "VariableByte"; }
 };
 
 class VByte : public IntegerCODEC {
-public:
-  template <uint32_t i> uint8_t extract7bits(const uint32_t val) {
+ public:
+  template <uint32_t i>
+  uint8_t extract7bits(const uint32_t val) {
     return static_cast<uint8_t>((val >> (7 * i)) & ((1U << 7) - 1));
   }
 
-  template <uint32_t i> uint8_t extract7bitsmaskless(const uint32_t val) {
+  template <uint32_t i>
+  uint8_t extract7bitsmaskless(const uint32_t val) {
     return static_cast<uint8_t>((val >> (7 * i)));
   }
 
@@ -247,7 +397,7 @@ public:
                                      uint32_t *out, size_t &nvalue) {
     if (length == 0) {
       nvalue = 0;
-      return inbyte; // abort
+      return inbyte;  // abort
     }
     const uint8_t *const endbyte = inbyte + length;
     const uint32_t *const initout(out);
@@ -312,6 +462,6 @@ public:
   std::string name() const { return "VByte"; }
 };
 
-} // namespace FastPFor
+}  // namespace FastPForLib
 
 #endif /* VARIABLEBYTE_H_ */

--- a/src/bitpacking.cpp
+++ b/src/bitpacking.cpp
@@ -4,16 +4,15 @@
 
 namespace {
 
-template<uint8_t DELTA, uint8_t SHR> typename std::enable_if<(DELTA + SHR) < 32>::type
-  unpack_single_out(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
-
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) < 32>::type unpack_single_out(
+    const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
   *out = ((*in) >> SHR) % (1 << DELTA);
 }
 
-template<uint8_t DELTA, uint8_t SHR>
-  typename std::enable_if<(DELTA + SHR) >= 32>::type
-  unpack_single_out(const uint32_t *__restrict__ & in, uint32_t *__restrict__ out) {
-
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) >= 32>::type unpack_single_out(
+    const uint32_t *__restrict__ &in, uint32_t *__restrict__ out) {
   *out = (*in) >> SHR;
   ++in;
 
@@ -21,79 +20,217 @@ template<uint8_t DELTA, uint8_t SHR>
   *out |= ((*in) % (1U << NEXT_SHR)) << (32 - SHR);
 }
 
-template<uint16_t DELTA, uint16_t SHL, uint32_t MASK>
-  typename std::enable_if<DELTA + SHL >= 32>::type
-  pack_single_in(const uint32_t in, uint32_t *__restrict__& out) {
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) < 32>::type unpack_single_out(
+    const uint32_t *__restrict__ in, uint64_t *__restrict__ out) {
+  *out = ((static_cast<uint64_t>(*in)) >> SHR) % (1UL << DELTA);
+}
 
-  *out |= in << SHL;
-  ++out;
-
-  if (DELTA + SHL > 32) {
-    *out = (in  & MASK) >> (32 - SHL);
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) >= 32 && (DELTA + SHR) < 64>::type
+unpack_single_out(const uint32_t *__restrict__ &in,
+                  uint64_t *__restrict__ out) {
+  *out = static_cast<uint64_t>(*in) >> SHR;
+  ++in;
+  if (DELTA + SHR > 32) {
+    static const uint8_t NEXT_SHR = SHR + DELTA - 32;
+    *out |= static_cast<uint64_t>((*in) % (1U << NEXT_SHR)) << (32 - SHR);
   }
 }
 
-template<uint16_t DELTA, uint16_t SHL, uint32_t MASK>
-typename std::enable_if<DELTA + SHL < 32>::type
-  pack_single_in(const uint32_t in, uint32_t *__restrict__ out) {
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) >= 64>::type unpack_single_out(
+    const uint32_t *__restrict__ &in, uint64_t *__restrict__ out) {
+  *out = static_cast<uint64_t>(*in) >> SHR;
+  ++in;
 
+  *out |= static_cast<uint64_t>(*in) << (32 - SHR);
+  ++in;
+
+  if (DELTA + SHR > 64) {
+    static const uint8_t NEXT_SHR = DELTA + SHR - 64;
+    *out |= static_cast<uint64_t>((*in) % (1U << NEXT_SHR)) << (64 - SHR);
+  }
+}
+
+template <uint16_t DELTA, uint16_t SHL, uint32_t MASK>
+    typename std::enable_if <
+    DELTA + SHL<32>::type pack_single_in(const uint32_t in,
+                                         uint32_t *__restrict__ out) {
   if (SHL == 0) {
-    *out = in  & MASK;
+    *out = in & MASK;
   } else {
     *out |= (in & MASK) << SHL;
   }
 }
 
+template <uint16_t DELTA, uint16_t SHL, uint32_t MASK>
+typename std::enable_if<DELTA + SHL >= 32>::type pack_single_in(
+    const uint32_t in, uint32_t *__restrict__ &out) {
+  *out |= in << SHL;
+  ++out;
 
-template<uint16_t DELTA, uint16_t OINDEX = 0> struct Unroller {
-  static_assert(DELTA < 32, "");
+  if (DELTA + SHL > 32) {
+    *out = (in & MASK) >> (32 - SHL);
+  }
+}
 
-  static void Unpack(const uint32_t *__restrict__ & in, uint32_t *__restrict__ out) {
+template <uint16_t DELTA, uint16_t SHL, uint64_t MASK>
+    typename std::enable_if <
+    DELTA + SHL<32>::type pack_single_in64(const uint64_t in,
+                                           uint32_t *__restrict__ out) {
+  if (SHL == 0) {
+    *out = static_cast<uint32_t>(in & MASK);
+  } else {
+    *out |= (in & MASK) << SHL;
+  }
+}
+
+template <uint16_t DELTA, uint16_t SHL, uint64_t MASK>
+        typename std::enable_if < DELTA + SHL >= 32 &&
+    DELTA + SHL<64>::type pack_single_in64(const uint64_t in,
+                                           uint32_t *__restrict__ &out) {
+  if (SHL == 0) {
+    *out = static_cast<uint32_t>(in & MASK);
+  } else {
+    *out |= (in & MASK) << SHL;
+  }
+
+  ++out;
+
+  if (DELTA + SHL > 32) {
+    *out = static_cast<uint32_t>((in & MASK) >> (32 - SHL));
+  }
+}
+
+template <uint16_t DELTA, uint16_t SHL, uint64_t MASK>
+typename std::enable_if<DELTA + SHL >= 64>::type pack_single_in64(
+    const uint64_t in, uint32_t *__restrict__ &out) {
+  *out |= in << SHL;
+  ++out;
+
+  *out = static_cast<uint32_t>((in & MASK) >> (32 - SHL));
+  ++out;
+
+  if (DELTA + SHL > 64) {
+    *out = (in & MASK) >> (64 - SHL);
+  }
+}
+
+template <uint16_t DELTA, uint16_t OINDEX = 0>
+struct Unroller {
+  static void Unpack(const uint32_t *__restrict__ &in,
+                     uint32_t *__restrict__ out) {
     unpack_single_out<DELTA, (DELTA * OINDEX) % 32>(in, out + OINDEX);
 
     Unroller<DELTA, OINDEX + 1>::Unpack(in, out);
   }
 
-  static void Pack(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
-    pack_single_in<DELTA, (DELTA * OINDEX) % 32, (1U << DELTA) - 1 >(in[OINDEX], out);
+  static void Unpack(const uint32_t *__restrict__ &in,
+                     uint64_t *__restrict__ out) {
+    unpack_single_out<DELTA, (DELTA * OINDEX) % 32>(in, out + OINDEX);
+
+    Unroller<DELTA, OINDEX + 1>::Unpack(in, out);
+  }
+
+  static void Pack(const uint32_t *__restrict__ in,
+                   uint32_t *__restrict__ out) {
+    pack_single_in<DELTA, (DELTA * OINDEX) % 32, (1U << DELTA) - 1>(in[OINDEX],
+                                                                    out);
 
     Unroller<DELTA, OINDEX + 1>::Pack(in, out);
   }
 
-  static void PackNoMask(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+  static void Pack(const uint64_t *__restrict__ in,
+                   uint32_t *__restrict__ out) {
+    pack_single_in64<DELTA, (DELTA * OINDEX) % 32, (1UL << DELTA) - 1>(
+        in[OINDEX], out);
+
+    Unroller<DELTA, OINDEX + 1>::Pack(in, out);
+  }
+
+  static void PackNoMask(const uint32_t *__restrict__ in,
+                         uint32_t *__restrict__ out) {
     pack_single_in<DELTA, (DELTA * OINDEX) % 32, uint32_t(-1)>(in[OINDEX], out);
+
+    Unroller<DELTA, OINDEX + 1>::PackNoMask(in, out);
+  }
+
+  static void PackNoMask(const uint64_t *__restrict__ in,
+                         uint32_t *__restrict__ out) {
+    pack_single_in64<DELTA, (DELTA * OINDEX) % 32, uint64_t(-1)>(in[OINDEX],
+                                                                 out);
 
     Unroller<DELTA, OINDEX + 1>::PackNoMask(in, out);
   }
 };
 
-template<uint16_t DELTA> struct Unroller<DELTA, 31> {
+template <uint16_t DELTA>
+struct Unroller<DELTA, 31> {
   enum { SHIFT = (DELTA * 31) % 32 };
 
-  static void Unpack(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
-    out[31] = (*in) >> SHIFT ;
+  static void Unpack(const uint32_t *__restrict__ in,
+                     uint32_t *__restrict__ out) {
+    out[31] = (*in) >> SHIFT;
   }
 
-  static void Pack(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+  static void Unpack(const uint32_t *__restrict__ in,
+                     uint64_t *__restrict__ out) {
+    out[31] = (*in) >> SHIFT;
+    if (DELTA > 32) {
+      ++in;
+      out[31] |= static_cast<uint64_t>(*in) << (32 - SHIFT);
+    }
+  }
+
+  static void Pack(const uint32_t *__restrict__ in,
+                   uint32_t *__restrict__ out) {
     *out |= (in[31] << SHIFT);
   }
 
-  static void PackNoMask(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+  static void Pack(const uint64_t *__restrict__ in,
+                   uint32_t *__restrict__ out) {
     *out |= (in[31] << SHIFT);
+    if (DELTA > 32) {
+      ++out;
+      *out = static_cast<uint32_t>(in[31] >> (32 - SHIFT));
+    }
+  }
+
+  static void PackNoMask(const uint32_t *__restrict__ in,
+                         uint32_t *__restrict__ out) {
+    *out |= (in[31] << SHIFT);
+  }
+
+  static void PackNoMask(const uint64_t *__restrict__ in,
+                         uint32_t *__restrict__ out) {
+    *out |= (in[31] << SHIFT);
+    if (DELTA > 32) {
+      ++out;
+      *out = static_cast<uint32_t>(in[31] >> (32 - SHIFT));
+    }
   }
 };
-
 }  // namespace
 
-
+// Special cases
 void __fastunpack0(const uint32_t *__restrict__, uint32_t *__restrict__ out) {
-  for (uint32_t i = 0; i < 32; ++i)
-    *(out++) = 0;
+  for (uint32_t i = 0; i < 32; ++i) *(out++) = 0;
 }
+
+void __fastunpack0(const uint32_t *__restrict__, uint64_t *__restrict__ out) {
+  for (uint32_t i = 0; i < 32; ++i) *(out++) = 0;
+}
+
 void __fastpack0(const uint32_t *__restrict__, uint32_t *__restrict__) {}
+void __fastpack0(const uint64_t *__restrict__, uint32_t *__restrict__) {}
+
 void __fastpackwithoutmask0(const uint32_t *__restrict__,
                             uint32_t *__restrict__) {}
+void __fastpackwithoutmask0(const uint64_t *__restrict__,
+                            uint32_t *__restrict__) {}
 
+// fastunpack for 32 bits
 void __fastunpack1(const uint32_t *__restrict__ in,
                    uint32_t *__restrict__ out) {
   Unroller<1>::Unpack(in, out);
@@ -109,6 +246,15 @@ void __fastunpack3(const uint32_t *__restrict__ in,
   Unroller<3>::Unpack(in, out);
 }
 
+void __fastunpack4(const uint32_t *__restrict__ in,
+                   uint32_t *__restrict__ out) {
+  for (uint32_t outer = 0; outer < 4; ++outer) {
+    for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 4)
+      *(out++) = ((*in) >> inwordpointer) % (1U << 4);
+    ++in;
+  }
+}
+
 void __fastunpack5(const uint32_t *__restrict__ in,
                    uint32_t *__restrict__ out) {
   Unroller<5>::Unpack(in, out);
@@ -122,6 +268,15 @@ void __fastunpack6(const uint32_t *__restrict__ in,
 void __fastunpack7(const uint32_t *__restrict__ in,
                    uint32_t *__restrict__ out) {
   Unroller<7>::Unpack(in, out);
+}
+
+void __fastunpack8(const uint32_t *__restrict__ in,
+                   uint32_t *__restrict__ out) {
+  for (uint32_t outer = 0; outer < 8; ++outer) {
+    for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 8)
+      *(out++) = ((*in) >> inwordpointer) % (1U << 8);
+    ++in;
+  }
 }
 
 void __fastunpack9(const uint32_t *__restrict__ in,
@@ -156,8 +311,16 @@ void __fastunpack14(const uint32_t *__restrict__ in,
 
 void __fastunpack15(const uint32_t *__restrict__ in,
                     uint32_t *__restrict__ out) {
-
   Unroller<15>::Unpack(in, out);
+}
+
+void __fastunpack16(const uint32_t *__restrict__ in,
+                    uint32_t *__restrict__ out) {
+  for (uint32_t outer = 0; outer < 16; ++outer) {
+    for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 16)
+      *(out++) = ((*in) >> inwordpointer) % (1U << 16);
+    ++in;
+  }
 }
 
 void __fastunpack17(const uint32_t *__restrict__ in,
@@ -237,22 +400,27 @@ void __fastunpack31(const uint32_t *__restrict__ in,
 
 void __fastunpack32(const uint32_t *__restrict__ in,
                     uint32_t *__restrict__ out) {
-  for (int k = 0; k < 32; ++k)
-    out[k] = in[k];
-}
-void __fastpack32(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
-  for (int k = 0; k < 32; ++k)
-    out[k] = in[k];
+  for (int k = 0; k < 32; ++k) out[k] = in[k];
 }
 
-void __fastpackwithoutmask32(const uint32_t *__restrict__ in,
-                             uint32_t *__restrict__ out) {
-  for (int k = 0; k < 32; ++k)
-    out[k] = in[k];
+// fastupack for 64 bits
+void __fastunpack1(const uint32_t *__restrict__ in,
+                   uint64_t *__restrict__ out) {
+  Unroller<1>::Unpack(in, out);
+}
+
+void __fastunpack2(const uint32_t *__restrict__ in,
+                   uint64_t *__restrict__ out) {
+  Unroller<2>::Unpack(in, out);
+}
+
+void __fastunpack3(const uint32_t *__restrict__ in,
+                   uint64_t *__restrict__ out) {
+  Unroller<3>::Unpack(in, out);
 }
 
 void __fastunpack4(const uint32_t *__restrict__ in,
-                   uint32_t *__restrict__ out) {
+                   uint64_t *__restrict__ out) {
   for (uint32_t outer = 0; outer < 4; ++outer) {
     for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 4)
       *(out++) = ((*in) >> inwordpointer) % (1U << 4);
@@ -260,23 +428,319 @@ void __fastunpack4(const uint32_t *__restrict__ in,
   }
 }
 
+void __fastunpack5(const uint32_t *__restrict__ in,
+                   uint64_t *__restrict__ out) {
+  Unroller<5>::Unpack(in, out);
+}
+
+void __fastunpack6(const uint32_t *__restrict__ in,
+                   uint64_t *__restrict__ out) {
+  Unroller<6>::Unpack(in, out);
+}
+
+void __fastunpack7(const uint32_t *__restrict__ in,
+                   uint64_t *__restrict__ out) {
+  Unroller<7>::Unpack(in, out);
+}
+
 void __fastunpack8(const uint32_t *__restrict__ in,
-                   uint32_t *__restrict__ out) {
+                   uint64_t *__restrict__ out) {
   for (uint32_t outer = 0; outer < 8; ++outer) {
-    for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 8)
+    for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 8) {
       *(out++) = ((*in) >> inwordpointer) % (1U << 8);
+    }
     ++in;
   }
 }
 
+void __fastunpack9(const uint32_t *__restrict__ in,
+                   uint64_t *__restrict__ out) {
+  Unroller<9>::Unpack(in, out);
+}
+
+void __fastunpack10(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<10>::Unpack(in, out);
+}
+
+void __fastunpack11(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<11>::Unpack(in, out);
+}
+
+void __fastunpack12(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<12>::Unpack(in, out);
+}
+
+void __fastunpack13(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<13>::Unpack(in, out);
+}
+
+void __fastunpack14(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<14>::Unpack(in, out);
+}
+
+void __fastunpack15(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<15>::Unpack(in, out);
+}
+
 void __fastunpack16(const uint32_t *__restrict__ in,
-                    uint32_t *__restrict__ out) {
+                    uint64_t *__restrict__ out) {
   for (uint32_t outer = 0; outer < 16; ++outer) {
     for (uint32_t inwordpointer = 0; inwordpointer < 32; inwordpointer += 16)
       *(out++) = ((*in) >> inwordpointer) % (1U << 16);
     ++in;
   }
 }
+
+void __fastunpack17(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<17>::Unpack(in, out);
+}
+
+void __fastunpack18(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<18>::Unpack(in, out);
+}
+
+void __fastunpack19(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<19>::Unpack(in, out);
+}
+
+void __fastunpack20(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<20>::Unpack(in, out);
+}
+
+void __fastunpack21(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<21>::Unpack(in, out);
+}
+
+void __fastunpack22(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<22>::Unpack(in, out);
+}
+
+void __fastunpack23(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<23>::Unpack(in, out);
+}
+
+void __fastunpack24(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<24>::Unpack(in, out);
+}
+
+void __fastunpack25(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<25>::Unpack(in, out);
+}
+
+void __fastunpack26(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<26>::Unpack(in, out);
+}
+
+void __fastunpack27(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<27>::Unpack(in, out);
+}
+
+void __fastunpack28(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<28>::Unpack(in, out);
+}
+
+void __fastunpack29(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<29>::Unpack(in, out);
+}
+
+void __fastunpack30(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<30>::Unpack(in, out);
+}
+
+void __fastunpack31(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<31>::Unpack(in, out);
+}
+
+void __fastunpack32(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  for (int k = 0; k < 32; ++k) out[k] = in[k];
+}
+
+void __fastunpack33(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<33>::Unpack(in, out);
+}
+
+void __fastunpack34(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<34>::Unpack(in, out);
+}
+
+void __fastunpack35(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<35>::Unpack(in, out);
+}
+
+void __fastunpack36(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<36>::Unpack(in, out);
+}
+
+void __fastunpack37(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<37>::Unpack(in, out);
+}
+
+void __fastunpack38(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<38>::Unpack(in, out);
+}
+
+void __fastunpack39(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<39>::Unpack(in, out);
+}
+
+void __fastunpack40(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<40>::Unpack(in, out);
+}
+
+void __fastunpack41(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<41>::Unpack(in, out);
+}
+
+void __fastunpack42(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<42>::Unpack(in, out);
+}
+
+void __fastunpack43(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<43>::Unpack(in, out);
+}
+
+void __fastunpack44(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<44>::Unpack(in, out);
+}
+
+void __fastunpack45(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<45>::Unpack(in, out);
+}
+
+void __fastunpack46(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<46>::Unpack(in, out);
+}
+
+void __fastunpack47(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<47>::Unpack(in, out);
+}
+
+void __fastunpack48(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<48>::Unpack(in, out);
+}
+
+void __fastunpack49(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<49>::Unpack(in, out);
+}
+
+void __fastunpack50(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<50>::Unpack(in, out);
+}
+
+void __fastunpack51(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<51>::Unpack(in, out);
+}
+
+void __fastunpack52(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<52>::Unpack(in, out);
+}
+
+void __fastunpack53(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<53>::Unpack(in, out);
+}
+
+void __fastunpack54(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<54>::Unpack(in, out);
+}
+
+void __fastunpack55(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<55>::Unpack(in, out);
+}
+
+void __fastunpack56(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<56>::Unpack(in, out);
+}
+
+void __fastunpack57(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<57>::Unpack(in, out);
+}
+
+void __fastunpack58(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<58>::Unpack(in, out);
+}
+
+void __fastunpack59(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<59>::Unpack(in, out);
+}
+
+void __fastunpack60(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<60>::Unpack(in, out);
+}
+
+void __fastunpack61(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<61>::Unpack(in, out);
+}
+
+void __fastunpack62(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<62>::Unpack(in, out);
+}
+
+void __fastunpack63(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  Unroller<63>::Unpack(in, out);
+}
+
+void __fastunpack64(const uint32_t *__restrict__ in,
+                    uint64_t *__restrict__ out) {
+  for (int k = 0; k < 32; ++k) {
+    out[k] = in[k * 2];
+    out[k] |= static_cast<uint64_t>(in[k * 2 + 1]) << 32;
+  }
+}
+
+// fastpack for 32 bits
 
 void __fastpack1(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<1>::Pack(in, out);
@@ -290,6 +754,10 @@ void __fastpack3(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<3>::Pack(in, out);
 }
 
+void __fastpack4(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<4>::Pack(in, out);
+}
+
 void __fastpack5(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<5>::Pack(in, out);
 }
@@ -300,6 +768,10 @@ void __fastpack6(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
 
 void __fastpack7(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<7>::Pack(in, out);
+}
+
+void __fastpack8(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<8>::Pack(in, out);
 }
 
 void __fastpack9(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
@@ -328,6 +800,10 @@ void __fastpack14(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
 
 void __fastpack15(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<15>::Pack(in, out);
+}
+
+void __fastpack16(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<16>::Pack(in, out);
 }
 
 void __fastpack17(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
@@ -390,18 +866,274 @@ void __fastpack31(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<31>::Pack(in, out);
 }
 
-void __fastpack4(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+void __fastpack32(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+  for (int k = 0; k < 32; ++k) out[k] = in[k];
+}
+
+// fastpack for 64 bits
+
+void __fastpack1(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<1>::Pack(in, out);
+}
+
+void __fastpack2(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<2>::Pack(in, out);
+}
+
+void __fastpack3(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<3>::Pack(in, out);
+}
+
+void __fastpack4(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<4>::Pack(in, out);
 }
 
-void __fastpack8(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+void __fastpack5(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<5>::Pack(in, out);
+}
+
+void __fastpack6(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<6>::Pack(in, out);
+}
+
+void __fastpack7(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<7>::Pack(in, out);
+}
+
+void __fastpack8(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<8>::Pack(in, out);
 }
 
-void __fastpack16(const uint32_t *__restrict__ in, uint32_t *__restrict__ out) {
+void __fastpack9(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<9>::Pack(in, out);
+}
+
+void __fastpack10(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<10>::Pack(in, out);
+}
+
+void __fastpack11(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<11>::Pack(in, out);
+}
+
+void __fastpack12(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<12>::Pack(in, out);
+}
+
+void __fastpack13(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<13>::Pack(in, out);
+}
+
+void __fastpack14(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<14>::Pack(in, out);
+}
+
+void __fastpack15(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<15>::Pack(in, out);
+}
+
+void __fastpack16(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
   Unroller<16>::Pack(in, out);
 }
 
+void __fastpack17(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<17>::Pack(in, out);
+}
+
+void __fastpack18(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<18>::Pack(in, out);
+}
+
+void __fastpack19(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<19>::Pack(in, out);
+}
+
+void __fastpack20(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<20>::Pack(in, out);
+}
+
+void __fastpack21(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<21>::Pack(in, out);
+}
+
+void __fastpack22(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<22>::Pack(in, out);
+}
+
+void __fastpack23(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<23>::Pack(in, out);
+}
+
+void __fastpack24(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<24>::Pack(in, out);
+}
+
+void __fastpack25(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<25>::Pack(in, out);
+}
+
+void __fastpack26(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<26>::Pack(in, out);
+}
+
+void __fastpack27(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<27>::Pack(in, out);
+}
+
+void __fastpack28(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<28>::Pack(in, out);
+}
+
+void __fastpack29(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<29>::Pack(in, out);
+}
+
+void __fastpack30(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<30>::Pack(in, out);
+}
+
+void __fastpack31(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<31>::Pack(in, out);
+}
+
+void __fastpack32(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  for (int k = 0; k < 32; ++k) {
+    out[k] = static_cast<uint32_t>(in[k]);
+  }
+}
+
+void __fastpack33(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<33>::Pack(in, out);
+}
+
+void __fastpack34(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<34>::Pack(in, out);
+}
+
+void __fastpack35(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<35>::Pack(in, out);
+}
+
+void __fastpack36(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<36>::Pack(in, out);
+}
+
+void __fastpack37(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<37>::Pack(in, out);
+}
+
+void __fastpack38(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<38>::Pack(in, out);
+}
+
+void __fastpack39(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<39>::Pack(in, out);
+}
+
+void __fastpack40(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<40>::Pack(in, out);
+}
+
+void __fastpack41(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<41>::Pack(in, out);
+}
+
+void __fastpack42(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<42>::Pack(in, out);
+}
+
+void __fastpack43(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<43>::Pack(in, out);
+}
+
+void __fastpack44(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<44>::Pack(in, out);
+}
+
+void __fastpack45(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<45>::Pack(in, out);
+}
+
+void __fastpack46(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<46>::Pack(in, out);
+}
+
+void __fastpack47(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<47>::Pack(in, out);
+}
+
+void __fastpack48(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<48>::Pack(in, out);
+}
+
+void __fastpack49(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<49>::Pack(in, out);
+}
+
+void __fastpack50(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<50>::Pack(in, out);
+}
+
+void __fastpack51(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<51>::Pack(in, out);
+}
+
+void __fastpack52(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<52>::Pack(in, out);
+}
+
+void __fastpack53(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<53>::Pack(in, out);
+}
+
+void __fastpack54(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<54>::Pack(in, out);
+}
+
+void __fastpack55(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<55>::Pack(in, out);
+}
+
+void __fastpack56(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<56>::Pack(in, out);
+}
+
+void __fastpack57(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<57>::Pack(in, out);
+}
+
+void __fastpack58(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<58>::Pack(in, out);
+}
+
+void __fastpack59(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<59>::Pack(in, out);
+}
+
+void __fastpack60(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<60>::Pack(in, out);
+}
+
+void __fastpack61(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<61>::Pack(in, out);
+}
+
+void __fastpack62(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<62>::Pack(in, out);
+}
+
+void __fastpack63(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  Unroller<63>::Pack(in, out);
+}
+
+void __fastpack64(const uint64_t *__restrict__ in, uint32_t *__restrict__ out) {
+  for (int i = 0; i < 32; ++i) {
+    out[2 * i] = static_cast<uint32_t>(in[i]);
+    out[2 * i + 1] = in[i] >> 32;
+  }
+}
+
+// fastpackwithoutmask for 32 bits
 /*assumes that integers fit in the prescribed number of bits */
 void __fastpackwithoutmask1(const uint32_t *__restrict__ in,
                             uint32_t *__restrict__ out) {
@@ -421,6 +1153,12 @@ void __fastpackwithoutmask3(const uint32_t *__restrict__ in,
 }
 
 /*assumes that integers fit in the prescribed number of bits */
+void __fastpackwithoutmask4(const uint32_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<4>::PackNoMask(in, out);
+}
+
+/*assumes that integers fit in the prescribed number of bits */
 void __fastpackwithoutmask5(const uint32_t *__restrict__ in,
                             uint32_t *__restrict__ out) {
   Unroller<5>::PackNoMask(in, out);
@@ -436,6 +1174,12 @@ void __fastpackwithoutmask6(const uint32_t *__restrict__ in,
 void __fastpackwithoutmask7(const uint32_t *__restrict__ in,
                             uint32_t *__restrict__ out) {
   Unroller<7>::PackNoMask(in, out);
+}
+
+/*assumes that integers fit in the prescribed number of bits */
+void __fastpackwithoutmask8(const uint32_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<8>::PackNoMask(in, out);
 }
 
 /*assumes that integers fit in the prescribed number of bits */
@@ -478,6 +1222,12 @@ void __fastpackwithoutmask14(const uint32_t *__restrict__ in,
 void __fastpackwithoutmask15(const uint32_t *__restrict__ in,
                              uint32_t *__restrict__ out) {
   Unroller<15>::PackNoMask(in, out);
+}
+
+/*assumes that integers fit in the prescribed number of bits */
+void __fastpackwithoutmask16(const uint32_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<16>::PackNoMask(in, out);
 }
 
 /*assumes that integers fit in the prescribed number of bits */
@@ -570,20 +1320,333 @@ void __fastpackwithoutmask31(const uint32_t *__restrict__ in,
   Unroller<31>::PackNoMask(in, out);
 }
 
-/*assumes that integers fit in the prescribed number of bits */
-void __fastpackwithoutmask4(const uint32_t *__restrict__ in,
+void __fastpackwithoutmask32(const uint32_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  for (int k = 0; k < 32; ++k) out[k] = in[k];
+}
+
+// fastpackwithoutmask for 64 bits
+void __fastpackwithoutmask1(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<1>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask2(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<2>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask3(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<3>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask4(const uint64_t *__restrict__ in,
                             uint32_t *__restrict__ out) {
   Unroller<4>::PackNoMask(in, out);
 }
 
-/*assumes that integers fit in the prescribed number of bits */
-void __fastpackwithoutmask8(const uint32_t *__restrict__ in,
+void __fastpackwithoutmask5(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<5>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask6(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<6>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask7(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<7>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask8(const uint64_t *__restrict__ in,
                             uint32_t *__restrict__ out) {
   Unroller<8>::PackNoMask(in, out);
 }
 
-/*assumes that integers fit in the prescribed number of bits */
-void __fastpackwithoutmask16(const uint32_t *__restrict__ in,
+void __fastpackwithoutmask9(const uint64_t *__restrict__ in,
+                            uint32_t *__restrict__ out) {
+  Unroller<9>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask10(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<10>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask11(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<11>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask12(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<12>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask13(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<13>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask14(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<14>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask15(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<15>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask16(const uint64_t *__restrict__ in,
                              uint32_t *__restrict__ out) {
   Unroller<16>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask17(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<17>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask18(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<18>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask19(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<19>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask20(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<20>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask21(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<21>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask22(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<22>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask23(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<23>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask24(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<24>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask25(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<25>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask26(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<26>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask27(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<27>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask28(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<28>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask29(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<29>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask30(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<30>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask31(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<31>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask32(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  for (int i = 0; i < 32; ++i) {
+    out[i] = static_cast<uint32_t>(in[i]);
+  }
+}
+
+void __fastpackwithoutmask33(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<33>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask34(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<34>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask35(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<35>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask36(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<36>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask37(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<37>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask38(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<38>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask39(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<39>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask40(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<40>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask41(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<41>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask42(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<42>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask43(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<43>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask44(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<44>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask45(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<45>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask46(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<46>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask47(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<47>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask48(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<48>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask49(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<49>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask50(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<50>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask51(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<51>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask52(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<52>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask53(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<53>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask54(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<54>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask55(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<55>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask56(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<56>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask57(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<57>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask58(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<58>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask59(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<59>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask60(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<60>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask61(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<61>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask62(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<62>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask63(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  Unroller<63>::PackNoMask(in, out);
+}
+
+void __fastpackwithoutmask64(const uint64_t *__restrict__ in,
+                             uint32_t *__restrict__ out) {
+  for (int i = 0; i < 32; ++i) {
+    out[2 * i] = static_cast<uint32_t>(in[i]);
+    out[2 * i + 1] = in[i] >> 32;
+  }
 }

--- a/unittest/test_composite.cpp
+++ b/unittest/test_composite.cpp
@@ -1,0 +1,157 @@
+#include <vector>
+#include <memory>
+#include <limits>
+#include <random>
+#include <cmath>
+
+#include "codecs.h"
+#include "compositecodec.h"
+#include "variablebyte.h"
+#include "fastpfor.h"
+
+#include "gtest/gtest.h"
+
+/*
+#ifdef __clang__
+  DIAGNOSTIC_IGNORE("-Wmissing-variable-declarations")
+#endif
+*/
+
+namespace FastPForLib {
+
+  class CompositeCodecTest : public ::testing::Test {
+    public:
+      virtual void SetUp();
+
+      protected:
+        std::unique_ptr<IntegerCODEC> codec;
+        std::vector<int32_t> in32, out32;
+        std::vector<uint32_t> encoded;
+        std::vector<int64_t> in64, out64;
+
+        void _verify() {
+          size_t inSize = in32.size();
+          encoded.resize(in32.size() * 2);
+          size_t encodeSize = encoded.size();
+
+          codec->encodeArray(
+                             reinterpret_cast<uint32_t *>(in32.data()),
+                             inSize,
+                             encoded.data(),
+                             encodeSize);
+
+          out32.resize(inSize);
+          codec->decodeArray(
+                             encoded.data(),
+                             encodeSize,
+                             reinterpret_cast<uint32_t *>(out32.data()),
+                             inSize);
+
+          for (size_t i = 0; i < inSize; ++i) {
+            EXPECT_EQ(in32[i], out32[i]);
+          }
+        }
+
+        void _verify64() {
+          size_t inSize = in64.size();
+          std::vector<uint32_t> encoded(in64.size() * 4);
+          size_t encodeSize = encoded.size();
+
+          codec->encodeArray(
+                             reinterpret_cast<uint64_t *>(in64.data()),
+                             inSize,
+                             encoded.data(),
+                             encodeSize);
+
+          out64.resize(inSize);
+          codec->decodeArray(
+                             encoded.data(),
+                             encodeSize,
+                             reinterpret_cast<uint64_t *>(out64.data()),
+                             inSize);
+
+          for (size_t i = 0; i < inSize; ++i) {
+            EXPECT_EQ(in64[i], out64[i]);
+          }
+        }
+
+        void _copy64() {
+          in64.clear();
+          for (size_t i = 0; i < in32.size(); ++i) {
+            in64.push_back(in32[i]);
+          }
+        }
+    };
+
+  void CompositeCodecTest::SetUp() {
+    codec.reset(new CompositeCodec<FastPFor<8>, VariableByte>());
+  }
+
+  TEST_F(CompositeCodecTest, emptyArray) {
+    in32.resize(0);
+    out32.resize(0);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_F(CompositeCodecTest, lessThanOneBlock) {
+    in32.resize(0);
+    for (int32_t i = 0; i < 255; i += 2) {
+      in32.push_back(i);
+    }
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_F(CompositeCodecTest, exactOneBlock) {
+    in32.resize(0);
+    for (int32_t i = 0; i < 256; i += 2) {
+      in32.push_back(i);
+    }
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_F(CompositeCodecTest, moreThanThreeBlock) {
+    in32.resize(0);
+    for (int i = 0; i < 1000; i = i + 3) {
+      in32.push_back(i);
+    }
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_F(CompositeCodecTest, randomeNumberMoreThanOnePage) {
+    in32.resize(0);
+    std::random_device rd;
+    std::mt19937_64 e2(rd());
+    std::uniform_int_distribution<int32_t> dist(
+                            std::numeric_limits<int32_t>::min(),
+                            std::numeric_limits<int32_t>::max());
+    std::srand(std::time(nullptr));
+    for (int i = 0; i < 70000; ++i) {
+      in32.push_back(dist(e2));
+    }
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_F(CompositeCodecTest, randomeNumberMoreThanOnePage64) {
+    in64.resize(0);
+    std::random_device rd;
+    std::mt19937_64 e2(rd());
+    std::uniform_int_distribution<int64_t> dist(
+                            std::numeric_limits<int64_t>::min(),
+                            std::numeric_limits<int64_t>::max());
+    std::srand(std::time(nullptr));
+    for (int i = 0; i < 70000; ++i) {
+      in64.push_back(dist(e2));
+    }
+    _verify64();
+  }
+}

--- a/unittest/test_driver.cpp
+++ b/unittest/test_driver.cpp
@@ -1,0 +1,6 @@
+#include "gtest/gtest.h"
+
+GTEST_API_ int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/unittest/test_fastpfor.cpp
+++ b/unittest/test_fastpfor.cpp
@@ -1,0 +1,399 @@
+#include <vector>
+#include <memory>
+#include <limits>
+#include <random>
+#include <cmath>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "codecs.h"
+#include "fastpfor.h"
+
+/*
+#ifdef __clang__
+  DIAGNOSTIC_IGNORE("-Wmissing-variable-declarations")
+#endif
+*/
+
+namespace FastPForLib {
+
+  using ::testing::TestWithParam;
+  using ::testing::Values;
+
+  class FastPForTest : public ::testing::TestWithParam<std::string> {
+    public:
+      virtual void SetUp() {
+        std::string name = GetParam();
+        if (name == "FastPFor128") {
+          codec.reset(new FastPFor<4>());
+        } else if (name == "FastPFor256") {
+          codec.reset(new FastPFor<8>());
+        } else {
+          throw new std::logic_error("Unknown codec " + name);
+        }
+      }
+
+      protected:
+        std::unique_ptr<IntegerCODEC> codec;
+        std::vector<int32_t> in32;
+        std::vector<int64_t> in64;
+        std::vector<int32_t> out32;
+        std::vector<int64_t> out64;
+
+        void _verify() {
+          size_t inSize = in32.size();
+          std::vector<uint32_t> encoded(in32.size() * 2, ~0);
+          size_t encodeSize = encoded.size();
+
+          codec->encodeArray(
+                             reinterpret_cast<uint32_t *>(in32.data()),
+                             inSize,
+                             encoded.data(),
+                             encodeSize);
+
+          out32.resize(inSize);
+          codec->decodeArray(
+                             encoded.data(),
+                             encodeSize,
+                             reinterpret_cast<uint32_t *>(out32.data()),
+                             inSize);
+
+          for (size_t i = 0; i < inSize; ++i) {
+            EXPECT_EQ(in32[i], out32[i]);
+          }
+        }
+
+        void _verify64() {
+          size_t inSize = in64.size();
+          std::vector<uint32_t> encoded(in64.size() * 4, ~0);
+          size_t encodeSize = encoded.size();
+
+          codec->encodeArray(
+                             reinterpret_cast<uint64_t *>(in64.data()),
+                             inSize,
+                             encoded.data(),
+                             encodeSize);
+
+          out64.resize(inSize);
+          codec->decodeArray(
+                             encoded.data(),
+                             encodeSize,
+                             reinterpret_cast<uint64_t *>(out64.data()),
+                             inSize);
+
+          for (size_t i = 0; i < inSize; ++i) {
+            EXPECT_EQ(in64[i], out64[i]);
+          }
+        }
+
+        void _copy64() {
+          in64.clear();
+          for (size_t i = 0; i < in32.size(); ++i) {
+            in64.push_back(in32[i]);
+          }
+        }
+
+        void _genDataRandom(std::vector<int32_t>& v, uint32_t values) {
+          v.clear();
+          std::random_device rd;
+          std::mt19937_64 e2(rd());
+          std::uniform_int_distribution<int32_t> dist(
+                                  std::numeric_limits<int32_t>::min(),
+                                  std::numeric_limits<int32_t>::max());
+          std::srand(std::time(nullptr));
+          for (int i = 0; i < values; ++i) {
+            v.push_back(dist(e2));
+          }
+        }
+
+        void _genDataRandom64(std::vector<int64_t>& v, uint32_t values) {
+          v.clear();
+          std::random_device rd;
+          std::mt19937_64 e2(rd());
+          std::uniform_int_distribution<int64_t> dist(
+                                  std::numeric_limits<int64_t>::min(),
+                                  std::numeric_limits<int64_t>::max());
+          std::srand(std::time(nullptr));
+          for (int i = 0; i < values; ++i) {
+            v.push_back(dist(e2));
+          }
+        }
+
+        void _genDataWithFixBits(
+                                 std::vector<int32_t>& v,
+                                 uint32_t bits,
+                                 uint32_t values) {
+          v.clear();
+          std::random_device rd;
+          std::mt19937_64 e2(rd());
+          std::uniform_int_distribution<uint32_t> dist(
+                                  0,
+                                  bits == 32 ? ~0U : (1U << bits) - 1);
+          std::srand(std::time(nullptr));
+          for (size_t i = 0; i < values; ++i) {
+            v.push_back(static_cast<int32_t>(dist(e2) | 1U << (bits - 1)));
+          }
+        }
+
+        void _genDataWithFixBits64(
+                                   std::vector<int64_t>& v,
+                                   uint32_t bits,
+                                   uint32_t values) {
+          v.clear();
+          std::random_device rd;
+          std::mt19937_64 e2(rd());
+          std::uniform_int_distribution<uint64_t> dist(
+                                  0,
+                                  bits == 64 ? ~0UL : (1UL << bits) - 1);
+          std::srand(std::time(nullptr));
+          for (size_t i = 0; i < values; ++i) {
+            v.push_back(static_cast<int32_t>(dist(e2) | 1UL << (bits - 1)));
+          }
+        }
+    };
+
+  TEST_P(FastPForTest, increasingSequence) {
+    in32.resize(0);
+    for (int i = -100; i < 156; ++i) {
+      in32.push_back(i);
+    }
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, randomNumbers) {
+    _genDataRandom(in32, 65536);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, randomNumbers64) {
+    _genDataRandom64(in64, 65536);
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, adHocNumbers64) {
+    int64_t data[] = {
+                -3673975021604308289,
+                277811506958363848,
+                -7625128575524920515,
+                -3321922176697690625,
+                -8484521102416600502,
+                4879706116117661039,
+                3108316356327171753,
+                -5023690236249800232};
+
+    in64.clear();
+    for (int i = 0; i < 64; ++i) {
+      for (int j = 0; j < 4; ++j) {
+        in64.push_back(data[j]);
+      }
+    }
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_zeors) {
+    in32.clear();
+    for (int i = 0; i < 256; ++i) {
+      in32.push_back(0);
+    }
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_zeros_with_exceptions) {
+    in32.clear();
+    in32.push_back(1024);
+    for (int i = 0; i < 254; ++i) {
+      in32.push_back(0);
+    }
+    in32.push_back(1033);
+
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_min_max) {
+    _genDataRandom(in32, 256);
+    in32[0] = std::numeric_limits<int32_t>::min();
+    in32[127] = std::numeric_limits<int32_t>::max();
+    in32[128] = std::numeric_limits<int32_t>::min();
+    in32[255] = std::numeric_limits<int32_t>::max();
+
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_min_max64) {
+    _genDataRandom64(in64, 256);
+    in64[0] = std::numeric_limits<int64_t>::min();
+    in64[127] = std::numeric_limits<int64_t>::max();
+    in64[128] = std::numeric_limits<int64_t>::min();
+    in64[255] = std::numeric_limits<int64_t>::max();
+
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_1_noexcept) {
+    _genDataWithFixBits(in32, 1, 1024);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_2_noexcept) {
+    _genDataWithFixBits(in32, 2, 1024);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_4_noexcept) {
+    _genDataWithFixBits(in32, 4, 1024);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_5_except) {
+    _genDataWithFixBits(in32, 5, 256);
+    in32[10] = 10002124;
+    in32[77] = 20002124;
+    in32[177] = 50002124;
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_8_noexcept) {
+    _genDataWithFixBits(in32, 8, 512);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_16_noexcept) {
+    _genDataWithFixBits(in32, 16, 256);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_22_noexcept) {
+    _genDataWithFixBits(in32, 22, 256);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_32_noexcept) {
+    _genDataWithFixBits(in32, 32, 768);
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_40_noexcept) {
+    _genDataWithFixBits64(in64, 40, 512);
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_41_noexcept) {
+    _genDataWithFixBits64(in64, 41, 512);
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_51_noexcept) {
+    _genDataWithFixBits64(in64, 51, 512);
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_56_noexcept) {
+    _genDataWithFixBits64(in64, 56, 512);
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_63_noexcept) {
+    _genDataWithFixBits64(in64, 63, 512);
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_64_noexcept) {
+    _genDataWithFixBits64(in64, 64, 768);
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_7_except_63) {
+    _genDataWithFixBits64(in64, 7, 256);
+    std::vector<int64_t> excepts;
+    _genDataWithFixBits64(excepts, 63, 6);
+    in64[0] = excepts[0];
+    in64[10] = excepts[1];
+    in64[100] = excepts[2];
+    in64[133] = excepts[3];
+    in64[177] = excepts[4];
+    in64[213] = excepts[5];
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_0_except_32) {
+    _genDataWithFixBits64(in64, 32, 256);
+    for (int i = 20; i < 40; ++i) {
+      in64[i] = 0;
+    }
+    for (int i = 155; i < 195; i += 2) {
+      in64[i] = 0;
+    }
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_3_except_64) {
+    _genDataWithFixBits64(in64, 3, 256);
+    for (int i = 20; i < 40; ++i) {
+      in64[i] = ~0UL - i;
+    }
+    for (int i = 155; i < 195; i += 2) {
+      in64[i] = ~0UL - i ;
+    }
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_13_with_small_numbers) {
+    _genDataWithFixBits(in32, 13, 256);
+    in32[20] = 3U << 5;
+    in32[60] = 2U << 4;
+    in32[150] = 7U << 3;
+    _verify();
+    _copy64();
+    _verify64();
+  }
+
+  TEST_P(FastPForTest, fastpack_35_with_excepts_and_small_numbers) {
+    _genDataWithFixBits64(in64, 35, 256);
+    std::vector<int64_t> excepts;
+    _genDataWithFixBits64(excepts, 48, 6);
+    in64[10] = 5U << 5;
+    in64[133] = 7U << 4;
+    in64[115] = 6U << 3;
+
+    in64[5] = excepts[0];
+    in64[21] = excepts[1];
+    in64[22] = excepts[2];
+    in64[137] = excepts[3];
+    in64[155] = excepts[4];
+    in64[221] = excepts[5];
+    _verify64();
+  }
+
+  INSTANTIATE_TEST_CASE_P(
+      FastPForLib,
+      FastPForTest,
+      Values("FastPFor128",
+             "FastPFor256"));
+}

--- a/unittest/test_variablebyte.cpp
+++ b/unittest/test_variablebyte.cpp
@@ -1,0 +1,173 @@
+#include <vector>
+#include <memory>
+#include <limits>
+#include <random>
+#include <cmath>
+
+#include "gtest/gtest.h"
+
+#include "codecs.h"
+#include "variablebyte.h"
+
+/*
+#ifdef __clang__
+  DIAGNOSTIC_IGNORE("-Wmissing-variable-declarations")
+#endif
+*/
+
+namespace FastPForLib {
+
+  class VariableByteTest : public ::testing::Test {
+    public:
+      virtual void SetUp();
+
+      protected:
+        std::unique_ptr<VariableByte> codec;
+        std::vector<int32_t> in32;
+        std::vector<int64_t> in64;
+        std::vector<uint32_t> encoded;
+        std::vector<int32_t> out32;
+        std::vector<int64_t> out64;
+
+        void _verify() {
+          size_t inSize = in32.size();
+          encoded.resize(in32.size() * 2);
+          size_t encodeSize = encoded.size();
+
+          codec->encodeArray(
+                             reinterpret_cast<uint32_t *>(in32.data()),
+                             inSize,
+                             encoded.data(),
+                             encodeSize);
+
+          out32.resize(inSize);
+          codec->decodeArray(
+                             encoded.data(),
+                             encodeSize,
+                             reinterpret_cast<uint32_t *>(out32.data()),
+                             inSize);
+
+          for (size_t i = 0; i < inSize; ++i) {
+            EXPECT_EQ(in32[i], out32[i]);
+          }
+        }
+
+        void _verify64() {
+          size_t inSize = in64.size();
+          encoded.resize(in64.size() * 4);
+          size_t encodeSize = encoded.size();
+
+          codec->encodeArray(
+                             reinterpret_cast<uint64_t *>(in64.data()),
+                             inSize,
+                             encoded.data(),
+                             encodeSize);
+
+          out64.resize(inSize);
+          codec->decodeArray(
+                             encoded.data(),
+                             encodeSize,
+                             reinterpret_cast<uint64_t *>(out64.data()),
+                             inSize);
+
+          for (size_t i = 0; i < inSize; ++i) {
+            EXPECT_EQ(in64[i], out64[i]);
+          }
+        }
+    };
+
+  void VariableByteTest::SetUp() {
+    codec.reset(new VariableByte());
+  }
+
+  TEST_F(VariableByteTest, emptyArray) {
+    in32.resize(0);
+    out32.resize(0);
+    _verify();
+  }
+
+  TEST_F(VariableByteTest, emptyArray64) {
+    in64.resize(0);
+    out64.resize(0);
+    _verify64();
+  }
+
+  TEST_F(VariableByteTest, increasingSequence) {
+    in32.resize(0);
+    for (int i = -20; i < 1000; ++i) {
+      in32.push_back(i);
+    }
+    _verify();
+  }
+
+  TEST_F(VariableByteTest, maxAndMin) {
+    in32.resize(0);
+    in32.push_back(std::numeric_limits<int32_t>::min());
+    in32.push_back(0);
+    in32.push_back(std::numeric_limits<int32_t>::max());
+    _verify();
+  }
+
+  TEST_F(VariableByteTest, increasingSequence64) {
+    in64.resize(0);
+    for (int i = -25; i < 1111; ++i) {
+      in64.push_back(i);
+    }
+    _verify();
+  }
+
+  TEST_F(VariableByteTest, negativeIncreasingSequence64) {
+    in64.resize(0);
+    int64_t start = -9223372036854775800;
+    for (int64_t i = 0; i < 3000; ++i) {
+      in64.push_back(start + i);
+    }
+    _verify64();
+  }
+
+  TEST_F(VariableByteTest, positiveDecreasingSequence64) {
+    in64.resize(0);
+    int64_t start = 9223372036854775800;
+    for (int64_t i = 0; i < 1555; ++i) {
+      in64.push_back(start - i);
+    }
+    _verify64();
+  }
+
+  TEST_F(VariableByteTest, maxAndMin64) {
+    in64.resize(0);
+    in64.push_back(std::numeric_limits<int64_t>::min());
+    in64.push_back(0);
+    in64.push_back(std::numeric_limits<int64_t>::max());
+    _verify64();
+  }
+
+  TEST_F(VariableByteTest, sequenceHasBoth32And64) {
+    in64.resize(0);
+    in64.push_back(-9223372036854775000);
+    in64.push_back(-32767);
+    in64.push_back(-300);
+    in64.push_back(0);
+    in64.push_back(500);
+    in64.push_back(32767);
+    in64.push_back(65536);
+    in64.push_back(2147483647);
+    in64.push_back(4294967295);
+    in64.push_back(8223372036854775800);
+    _verify64();
+  }
+
+  TEST_F(VariableByteTest, randomNumbers5000) {
+    in64.resize(0);
+    std::random_device rd;
+    std::mt19937_64 e2(rd());
+    std::uniform_int_distribution<int64_t> dist(
+                            std::numeric_limits<int64_t>::min(),
+                            std::numeric_limits<int64_t>::max());
+    std::srand(std::time(nullptr));
+    for (int i = 0; i < 5000; ++i) {
+      in64.push_back(dist(e2));
+    }
+    _verify64();
+  }
+}


### PR DESCRIPTION
1. Add a new template parameter for FastPFor encoder to specify the integer type. Curently uint32_t and uint64_t are supported.
2. Add corresponding bit packing and unpacking functions for 64-bit integers.
3. Overload IntegerCODEC interfaces to provide 64bit version of encodeArray() and decodeArray(). For codes that don't support 64bit, those would just throw not implemented exception.
4. Add 64-bit support for CompositeCodec and VariableByte, so the encoding and decoding can work end to end with arbitary number of integers.
5. Add gtest to the CMake project and create unittests for the new 64 bit support.
6. Replace some of the assertions into exceptions.