### PR TITLE
avoid mulitple redefinition when include from different .c/.cpp files.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - mkdir build
   - cd build
   - ps: cmake -G "$env:GENERATOR" ..
-  - cmake --build . --config Debug
+  - cmake --build . --config Release
 
 test_script:
   - ctest --verbose

--- a/headers/codecfactory.h
+++ b/headers/codecfactory.h
@@ -149,7 +149,7 @@ static inline CodecMap initializefactory() {
   return map;
 }
 
-CodecMap CODECFactory::scodecmap = initializefactory();
+inline CodecMap CODECFactory::scodecmap = initializefactory();
 
 } // namespace FastPFor
 

--- a/headers/deltautil.h
+++ b/headers/deltautil.h
@@ -61,7 +61,7 @@ struct algostats {
   bool SIMDDeltas;
 };
 
-void summarize(std::vector<algostats> &v, std::string prefix = "#") {
+static void summarize(std::vector<algostats> &v, std::string prefix = "#") {
   if (v.empty())
     return;
   std::cout << "# building summary " << std::endl;

--- a/headers/entropy.h
+++ b/headers/entropy.h
@@ -62,7 +62,7 @@ public:
  * An entropic measure,
  * Index compression using 64-bit words by Vo Ngoc Anh and Alistair Moffat
  */
-__attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
+static __attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
   double sum = 0.0;
   for (size_t k = 0; k < length; ++k) {
     sum += static_cast<double>(gccbits(in[k])) / static_cast<double>(length);
@@ -70,7 +70,7 @@ __attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
   return sum;
 }
 
-double entropy(const uint32_t *in, const size_t length) {
+static double entropy(const uint32_t *in, const size_t length) {
   if (length == 0)
     return 0;
   std::map<uint32_t, double> counter;

--- a/headers/simple8b_rle.h
+++ b/headers/simple8b_rle.h
@@ -238,7 +238,7 @@ public:
   }
 };
 
-const uint32_t Simple8b_Codec::bitLength[] = {1, 1,  2,  3,  4,  5,  6,  7,
+inline const uint32_t Simple8b_Codec::bitLength[] = {1, 1,  2,  3,  4,  5,  6,  7,
                                               8, 10, 12, 15, 20, 30, 60, 32};
 // const uint32_t Simple8b_Codec::bitLength[] = { 1, 2, 3, 4, 5, 6, 6, 7, 8, 9,
 // 10, 12, 15, 20, 30, 32 };

--- a/headers/simple9_rle.h
+++ b/headers/simple9_rle.h
@@ -255,9 +255,9 @@ public:
 
 // --------------------------- selector code:  0,  1,  2,  3,  4,  5,  6,  7,
 // 8,  9,  A,  B,  C,  D,  E,  F
-const uint32_t Simple9_Codec::intNumber[] = {28, 14, 9, 7, 5, 4, 3, 2,
+inline const uint32_t Simple9_Codec::intNumber[] = {28, 14, 9, 7, 5, 4, 3, 2,
                                              1,  1,  1, 1, 1, 1, 1, 1};
-const uint32_t Simple9_Codec::bitLength[] = {1,  2,  3,  4,  5,  7,  9,  14,
+inline const uint32_t Simple9_Codec::bitLength[] = {1,  2,  3,  4,  5,  7,  9,  14,
                                              31, 31, 31, 31, 31, 31, 31, 31};
 
 /**

--- a/headers/vsencoding.h
+++ b/headers/vsencoding.h
@@ -53,10 +53,10 @@ private:
 public:
   uint32_t written;
 
-  BitsWriter(uint32_t *out);
-  void bit_flush();
+  inline BitsWriter(uint32_t *out);
+  inline void bit_flush();
 
-  void bit_writer(uint32_t value, uint32_t bits);
+  inline void bit_writer(uint32_t value, uint32_t bits);
 };
 
 BitsWriter::BitsWriter(uint32_t *out)
@@ -119,14 +119,14 @@ private:
   uint32_t maxBlk;
 
 public:
-  VSEncoding(uint32_t *lens, uint32_t *zlens, uint32_t size, bool cflag);
+  inline VSEncoding(uint32_t *lens, uint32_t *zlens, uint32_t size, bool cflag);
 
   /*
    * Compute the optimal sub-lists from lists.
    *      len: The length of the sequence of lists
    *      fixCost: The fix cost in bits that we pay for  each block
    */
-  uint32_t *compute_OptPartition(uint32_t *seq, uint32_t len, uint32_t fixCost,
+  inline uint32_t *compute_OptPartition(uint32_t *seq, uint32_t len, uint32_t fixCost,
                                  uint32_t &pSize);
 };
 
@@ -298,10 +298,10 @@ public:
       : VSENCODING_BLOCKSZ(mVSENCODING_BLOCKSZ),
         __tmp(VSENCODING_BLOCKSZ * 4 + VSEncodingBlocks::TAIL_MERGIN) {}
 
-  void encodeVS(uint32_t len, const uint32_t *in, uint32_t &size,
+  inline void encodeVS(uint32_t len, const uint32_t *in, uint32_t &size,
                 uint32_t *out);
 
-  const uint32_t *decodeVS(uint32_t len, const uint32_t *in, uint32_t *out,
+  inline const uint32_t *decodeVS(uint32_t len, const uint32_t *in, uint32_t *out,
                            uint32_t *aux);
   std::string name() const { return "VSEncoding"; }
 
@@ -313,10 +313,10 @@ public:
    *
    * Note: *out must be large enough to contain the compress.
    */
-  void encodeArray(const uint32_t *in, const size_t len, uint32_t *out,
+  inline void encodeArray(const uint32_t *in, const size_t len, uint32_t *out,
                    size_t &nvalue);
 
-  const uint32_t *decodeArray(const uint32_t *in, const size_t len,
+  inline const uint32_t *decodeArray(const uint32_t *in, const size_t len,
                               uint32_t *out, size_t &nvalue);
   uint32_t VSENCODING_BLOCKSZ; //     = 65536U
 


### PR DESCRIPTION
when  #include "headers/codecfactory.h" from two cpp in a project, meet  "multiple definition of xxx"