### PR TITLE
Avoid multiple redefinition when including codecfactory.h from different .cpp files

### DIFF
--- a/headers/codecfactory.h
+++ b/headers/codecfactory.h
@@ -48,12 +48,13 @@ typedef std::map<std::string, std::shared_ptr<IntegerCODEC>> CodecMap;
  */
 class CODECFactory {
 public:
-  static CodecMap scodecmap;
+  static CodecMap& scodecmap();
 
   // hacked for convenience
   static std::vector<std::shared_ptr<IntegerCODEC>> allSchemes() {
     std::vector<std::shared_ptr<IntegerCODEC>> ans;
-    for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
+    CodecMap& codecs = scodecmap();
+    for (auto i = codecs.begin(); i != codecs.end(); ++i) {
       ans.push_back(i->second);
     }
     return ans;
@@ -61,25 +62,27 @@ public:
 
   static std::vector<std::string> allNames() {
     std::vector<std::string> ans;
-    for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
+    CodecMap& codecs = scodecmap();
+    for (auto i = codecs.begin(); i != codecs.end(); ++i) {
       ans.push_back(i->first);
     }
     return ans;
   }
 
   static std::shared_ptr<IntegerCODEC> &getFromName(std::string name) {
-    if (scodecmap.find(name) == scodecmap.end()) {
+    CodecMap& codecs = scodecmap();
+    if (codecs.find(name) == codecs.end()) {
       std::cerr << "name " << name << " does not refer to a CODEC."
                 << std::endl;
       std::cerr << "possible choices:" << std::endl;
-      for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
+      for (auto i = codecs.begin(); i != codecs.end(); ++i) {
         std::cerr << static_cast<std::string>(i->first)
                   << std::endl; // useless cast, but just to be clear
       }
       std::cerr << "for now, I'm going to just return 'copy'" << std::endl;
-      return scodecmap["copy"];
+      return codecs["copy"];
     }
-    return scodecmap[name];
+    return codecs[name];
   }
 };
 
@@ -149,7 +152,11 @@ static inline CodecMap initializefactory() {
   return map;
 }
 
-CodecMap CODECFactory::scodecmap = initializefactory();
+inline CodecMap& CODECFactory::scodecmap()
+{
+  static CodecMap scodecmap = initializefactory();
+  return scodecmap;
+}
 
 } // namespace FastPFor
 

--- a/headers/deltautil.h
+++ b/headers/deltautil.h
@@ -61,7 +61,7 @@ struct algostats {
   bool SIMDDeltas;
 };
 
-void summarize(std::vector<algostats> &v, std::string prefix = "#") {
+static void summarize(std::vector<algostats> &v, std::string prefix = "#") {
   if (v.empty())
     return;
   std::cout << "# building summary " << std::endl;

--- a/headers/entropy.h
+++ b/headers/entropy.h
@@ -62,7 +62,7 @@ public:
  * An entropic measure,
  * Index compression using 64-bit words by Vo Ngoc Anh and Alistair Moffat
  */
-__attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
+static __attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
   double sum = 0.0;
   for (size_t k = 0; k < length; ++k) {
     sum += static_cast<double>(gccbits(in[k])) / static_cast<double>(length);
@@ -70,7 +70,7 @@ __attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
   return sum;
 }
 
-double entropy(const uint32_t *in, const size_t length) {
+static double entropy(const uint32_t *in, const size_t length) {
   if (length == 0)
     return 0;
   std::map<uint32_t, double> counter;


### PR DESCRIPTION
fixes #83