### PR TITLE
Avoid multiple redefinition when including codecfactory.h from different .cpp 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(FastPFOR STATIC
     src/bitpackingunaligned.cpp
     src/horizontalbitpacking.cpp
     src/simdunalignedbitpacking.cpp
+    src/codecfactory.cpp
     src/simdbitpacking.cpp
     src/varintdecode.c
     src/streamvbyte.c)

--- a/example.cpp
+++ b/example.cpp
@@ -14,9 +14,10 @@
 
 int main() {
   using namespace FastPForLib;
+  CODECFactory factory;
 
   // We pick a CODEC
-  IntegerCODEC &codec = *CODECFactory::getFromName("simdfastpfor256");
+  IntegerCODEC &codec = *factory.getFromName("simdfastpfor256");
   // could use others, e.g., "simdbinarypacking", "varintg8iu"
   ////////////
   //

--- a/headers/codecfactory.h
+++ b/headers/codecfactory.h
@@ -41,45 +41,19 @@ namespace FastPForLib {
 typedef std::map<std::string, std::shared_ptr<IntegerCODEC>> CodecMap;
 
 /**
- * This class is a convenience class to generate codecs quickly.
- * It cannot be used safely in a multithreaded context where
- * each thread should have a different IntegerCODEC.
+ * You should have at least one factory per thread.
  */
 class CODECFactory {
 public:
-  static CodecMap scodecmap;
+  CODECFactory();
 
-  // hacked for convenience
-  static std::vector<std::shared_ptr<IntegerCODEC>> allSchemes() {
-    std::vector<std::shared_ptr<IntegerCODEC>> ans;
-    for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
-      ans.push_back(i->second);
-    }
-    return ans;
-  }
+  std::vector<std::shared_ptr<IntegerCODEC>> allSchemes();
 
-  static std::vector<std::string> allNames() {
-    std::vector<std::string> ans;
-    for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
-      ans.push_back(i->first);
-    }
-    return ans;
-  }
+  std::vector<std::string> allNames();
 
-  static std::shared_ptr<IntegerCODEC> &getFromName(std::string name) {
-    if (scodecmap.find(name) == scodecmap.end()) {
-      std::cerr << "name " << name << " does not refer to a CODEC."
-                << std::endl;
-      std::cerr << "possible choices:" << std::endl;
-      for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
-        std::cerr << static_cast<std::string>(i->first)
-                  << std::endl; // useless cast, but just to be clear
-      }
-      std::cerr << "for now, I'm going to just return 'copy'" << std::endl;
-      return scodecmap["copy"];
-    }
-    return scodecmap[name];
-  }
+  std::shared_ptr<IntegerCODEC> &getFromName(std::string name);
+private:
+  CodecMap scodecmap;
 };
 
 

--- a/headers/codecfactory.h
+++ b/headers/codecfactory.h
@@ -7,7 +7,6 @@
 
 #ifndef CODECFACTORY_H_
 #define CODECFACTORY_H_
-
 #include "common.h"
 #include "codecs.h"
 #include "vsencoding.h"
@@ -83,73 +82,6 @@ public:
   }
 };
 
-// C++11 allows better than this, but neither Microsoft nor Intel support C++11
-// fully.
-static inline CodecMap initializefactory() {
-  CodecMap map;
-  map["fastbinarypacking8"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<FastBinaryPacking<8>, VariableByte>);
-  map["fastbinarypacking16"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<FastBinaryPacking<16>, VariableByte>);
-  map["fastbinarypacking32"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<FastBinaryPacking<32>, VariableByte>);
-  map["BP32"] =
-      std::shared_ptr<IntegerCODEC>(new CompositeCodec<BP32, VariableByte>);
-  map["vsencoding"] =
-      std::shared_ptr<IntegerCODEC>(new vsencoding::VSEncodingBlocks(1U << 16));
-  map["fastpfor128"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<FastPFor<4>, VariableByte>());
-  map["fastpfor256"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<FastPFor<8>, VariableByte>());
-  map["simdfastpfor128"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDFastPFor<4>, VariableByte>());
-  map["simdfastpfor256"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDFastPFor<8>, VariableByte>());
-  map["simplepfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SimplePFor<>, VariableByte>());
-  map["simdsimplepfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDSimplePFor<>, VariableByte>());
-  map["pfor"] =
-      std::shared_ptr<IntegerCODEC>(new CompositeCodec<PFor, VariableByte>());
-  map["simdpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDPFor, VariableByte>());
-  map["pfor2008"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<PFor2008, VariableByte>());
-  map["simdnewpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDNewPFor<4, Simple16<false>>, VariableByte>());
-  map["newpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<NewPFor<4, Simple16<false>>, VariableByte>());
-  map["optpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<OPTPFor<4, Simple16<false>>, VariableByte>());
-  map["simdoptpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDOPTPFor<4, Simple16<false>>, VariableByte>());
-  map["varint"] = std::shared_ptr<IntegerCODEC>(new VariableByte());
-  map["vbyte"] = std::shared_ptr<IntegerCODEC>(new VByte());
-  map["maskedvbyte"] = std::shared_ptr<IntegerCODEC>(new MaskedVByte());
-  map["streamvbyte"] = std::shared_ptr<IntegerCODEC>(new StreamVByte());
-  map["varintgb"] = std::shared_ptr<IntegerCODEC>(new VarIntGB<>());
-  map["simple16"] = std::shared_ptr<IntegerCODEC>(new Simple16<true>());
-  map["simple9"] = std::shared_ptr<IntegerCODEC>(new Simple9<true>());
-  map["simple9_rle"] = std::shared_ptr<IntegerCODEC>(new Simple9_RLE<true>());
-  map["simple8b"] = std::shared_ptr<IntegerCODEC>(new Simple8b<true>());
-  map["simple8b_rle"] = std::shared_ptr<IntegerCODEC>(new Simple8b_RLE<true>());
-#ifdef VARINTG8IU_H__
-  map["varintg8iu"] = std::shared_ptr<IntegerCODEC>(new VarIntG8IU());
-#endif
-#ifdef USESNAPPY
-  map["snappy"] = std::shared_ptr<IntegerCODEC>(new JustSnappy());
-#endif
-  map["simdbinarypacking"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDBinaryPacking, VariableByte>());
-  map["simdgroupsimple"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDGroupSimple<false, false>, VariableByte>());
-  map["simdgroupsimple_ringbuf"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDGroupSimple<true, true>, VariableByte>());
-  map["copy"] = std::shared_ptr<IntegerCODEC>(new JustCopy());
-  return map;
-}
-
-CodecMap CODECFactory::scodecmap = initializefactory();
 
 } // namespace FastPFor
 

--- a/headers/codecs.h
+++ b/headers/codecs.h
@@ -36,8 +36,8 @@ public:
   virtual void encodeArray(const uint32_t *in, const size_t length,
                            uint32_t *out, size_t &nvalue) = 0;
 
-  virtual void encodeArray(const uint64_t *in, const size_t length,
-                           uint32_t *out, size_t &nvalue) {
+  virtual void encodeArray(const uint64_t *, const size_t ,
+                           uint32_t *, size_t &) {
     throw std::logic_error("Not implemented!");
   }
   /**
@@ -57,8 +57,8 @@ public:
   virtual const uint32_t *decodeArray(const uint32_t *in, const size_t length,
                                       uint32_t *out, size_t &nvalue) = 0;
 
-  virtual const uint32_t *decodeArray(const uint32_t *in, const size_t length,
-                                      uint64_t *out, size_t &nvalue) {
+  virtual const uint32_t *decodeArray(const uint32_t *, const size_t ,
+                                      uint64_t *, size_t &) {
     throw std::logic_error("Not implemented!");
   }
 

--- a/headers/deltautil.h
+++ b/headers/deltautil.h
@@ -61,7 +61,7 @@ struct algostats {
   bool SIMDDeltas;
 };
 
-void summarize(std::vector<algostats> &v, std::string prefix = "#") {
+inline void summarize(std::vector<algostats> &v, std::string prefix = "#") {
   if (v.empty())
     return;
   std::cout << "# building summary " << std::endl;

--- a/headers/entropy.h
+++ b/headers/entropy.h
@@ -62,7 +62,7 @@ public:
  * An entropic measure,
  * Index compression using 64-bit words by Vo Ngoc Anh and Alistair Moffat
  */
-__attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
+inline __attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
   double sum = 0.0;
   for (size_t k = 0; k < length; ++k) {
     sum += static_cast<double>(gccbits(in[k])) / static_cast<double>(length);
@@ -70,7 +70,7 @@ __attribute__((pure)) double databits(const uint32_t *in, const size_t length) {
   return sum;
 }
 
-double entropy(const uint32_t *in, const size_t length) {
+inline double entropy(const uint32_t *in, const size_t length) {
   if (length == 0)
     return 0;
   std::map<uint32_t, double> counter;

--- a/headers/simdgroupsimple.h
+++ b/headers/simdgroupsimple.h
@@ -301,7 +301,7 @@ public:
    */
   inline static void comprCompleteBlock(const uint8_t &n, const __m128i *&in,
                                         __m128i *&out) {
-    __m128i res;
+    __m128i res = _mm_setzero_si128();
 
     // In the following, b means the bit width.
 
@@ -826,7 +826,7 @@ public:
       encodeArrayInternal_woRingBuf(in, len, out, nvalue);
   }
 
-  const uint32_t *decodeArray(const uint32_t *in, const size_t len,
+  const uint32_t *decodeArray(const uint32_t *in, const size_t,
                               uint32_t *out, size_t &nvalue) {
     if (needPaddingTo128Bits(out))
       throw std::runtime_error("the output buffer must be aligned to 16 bytes");

--- a/headers/simple8b_rle.h
+++ b/headers/simple8b_rle.h
@@ -271,8 +271,9 @@ public:
     nvalue = count * 2;
   }
 
-  const uint32_t *decodeArray(const uint32_t *in, const size_t,
+  const uint32_t *decodeArray(const uint32_t *in, const size_t length,
                               uint32_t *out, size_t &nvalue) {
+    (void)length;
 
     uint32_t markednvalue;
     if (MarkLength) {

--- a/headers/simple8b_rle.h
+++ b/headers/simple8b_rle.h
@@ -165,7 +165,7 @@ public:
     return outPos - outOffset;
   }
 
-  static uint32_t Decompress(const uint64_t *input, uint32_t inOffset,
+  static uint32_t Decompress(const uint64_t *input, uint32_t,
                              uint32_t *output, uint32_t outOffset,
                              uint32_t outCount) {
     uint32_t inPos = 0;
@@ -271,7 +271,7 @@ public:
     nvalue = count * 2;
   }
 
-  const uint32_t *decodeArray(const uint32_t *in, const size_t length,
+  const uint32_t *decodeArray(const uint32_t *in, const size_t,
                               uint32_t *out, size_t &nvalue) {
 
     uint32_t markednvalue;

--- a/headers/simple9_rle.h
+++ b/headers/simple9_rle.h
@@ -276,7 +276,7 @@ public:
     nvalue = count;
   }
 
-  const uint32_t *decodeArray(const uint32_t *input, const size_t length,
+  const uint32_t *decodeArray(const uint32_t *input, const size_t,
                               uint32_t *out, size_t &nvalue) {
     uint32_t markednvalue;
     if (MarkLength) {

--- a/src/codecfactory.cpp
+++ b/src/codecfactory.cpp
@@ -1,12 +1,35 @@
 #include "codecfactory.h"
 
-/**
- * We moved part of the factor to its own cpp file because some users
- * create multiple instances. Note that the factory is not meant to be
- * a safe class, it is a convenience class and you should just have one
- * instance of it per project.
- */
 namespace FastPForLib {
+std::vector<std::shared_ptr<IntegerCODEC>> CODECFactory::allSchemes() {
+  std::vector<std::shared_ptr<IntegerCODEC>> ans;
+  for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
+    ans.push_back(i->second);
+  }
+  return ans;
+}
+
+std::vector<std::string> CODECFactory::allNames() {
+  std::vector<std::string> ans;
+  for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
+    ans.push_back(i->first);
+  }
+  return ans;
+}
+
+std::shared_ptr<IntegerCODEC> &CODECFactory::getFromName(std::string name) {
+  if (scodecmap.find(name) == scodecmap.end()) {
+    std::cerr << "name " << name << " does not refer to a CODEC." << std::endl;
+    std::cerr << "possible choices:" << std::endl;
+    for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
+      std::cerr << static_cast<std::string>(i->first)
+                << std::endl; // useless cast, but just to be clear
+    }
+    std::cerr << "for now, I'm going to just return 'copy'" << std::endl;
+    return scodecmap["copy"];
+  }
+  return scodecmap[name];
+}
 
 // C++11 allows better than this, but neither Microsoft nor Intel support C++11
 // fully.
@@ -41,13 +64,13 @@ inline CodecMap initializefactory() {
   map["pfor2008"] = std::shared_ptr<IntegerCODEC>(
       new CompositeCodec<PFor2008, VariableByte>());
   map["simdnewpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDNewPFor<4, Simple16<false> >, VariableByte>());
+      new CompositeCodec<SIMDNewPFor<4, Simple16<false>>, VariableByte>());
   map["newpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<NewPFor<4, Simple16<false> >, VariableByte>());
+      new CompositeCodec<NewPFor<4, Simple16<false>>, VariableByte>());
   map["optpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<OPTPFor<4, Simple16<false> >, VariableByte>());
+      new CompositeCodec<OPTPFor<4, Simple16<false>>, VariableByte>());
   map["simdoptpfor"] = std::shared_ptr<IntegerCODEC>(
-      new CompositeCodec<SIMDOPTPFor<4, Simple16<false> >, VariableByte>());
+      new CompositeCodec<SIMDOPTPFor<4, Simple16<false>>, VariableByte>());
   map["varint"] = std::shared_ptr<IntegerCODEC>(new VariableByte());
   map["vbyte"] = std::shared_ptr<IntegerCODEC>(new VByte());
   map["maskedvbyte"] = std::shared_ptr<IntegerCODEC>(new MaskedVByte());
@@ -73,5 +96,5 @@ inline CodecMap initializefactory() {
   map["copy"] = std::shared_ptr<IntegerCODEC>(new JustCopy());
   return map;
 }
-CodecMap CODECFactory::scodecmap = initializefactory();
-}
+CODECFactory::CODECFactory() : scodecmap(initializefactory())  {}
+} // namespace FastPForLib

--- a/src/codecfactory.cpp
+++ b/src/codecfactory.cpp
@@ -1,0 +1,77 @@
+#include "codecfactory.h"
+
+/**
+ * We moved part of the factor to its own cpp file because some users
+ * create multiple instances. Note that the factory is not meant to be
+ * a safe class, it is a convenience class and you should just have one
+ * instance of it per project.
+ */
+namespace FastPForLib {
+
+// C++11 allows better than this, but neither Microsoft nor Intel support C++11
+// fully.
+inline CodecMap initializefactory() {
+  CodecMap map;
+  map["fastbinarypacking8"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<FastBinaryPacking<8>, VariableByte>);
+  map["fastbinarypacking16"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<FastBinaryPacking<16>, VariableByte>);
+  map["fastbinarypacking32"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<FastBinaryPacking<32>, VariableByte>);
+  map["BP32"] =
+      std::shared_ptr<IntegerCODEC>(new CompositeCodec<BP32, VariableByte>);
+  map["vsencoding"] =
+      std::shared_ptr<IntegerCODEC>(new vsencoding::VSEncodingBlocks(1U << 16));
+  map["fastpfor128"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<FastPFor<4>, VariableByte>());
+  map["fastpfor256"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<FastPFor<8>, VariableByte>());
+  map["simdfastpfor128"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDFastPFor<4>, VariableByte>());
+  map["simdfastpfor256"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDFastPFor<8>, VariableByte>());
+  map["simplepfor"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SimplePFor<>, VariableByte>());
+  map["simdsimplepfor"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDSimplePFor<>, VariableByte>());
+  map["pfor"] =
+      std::shared_ptr<IntegerCODEC>(new CompositeCodec<PFor, VariableByte>());
+  map["simdpfor"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDPFor, VariableByte>());
+  map["pfor2008"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<PFor2008, VariableByte>());
+  map["simdnewpfor"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDNewPFor<4, Simple16<false> >, VariableByte>());
+  map["newpfor"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<NewPFor<4, Simple16<false> >, VariableByte>());
+  map["optpfor"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<OPTPFor<4, Simple16<false> >, VariableByte>());
+  map["simdoptpfor"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDOPTPFor<4, Simple16<false> >, VariableByte>());
+  map["varint"] = std::shared_ptr<IntegerCODEC>(new VariableByte());
+  map["vbyte"] = std::shared_ptr<IntegerCODEC>(new VByte());
+  map["maskedvbyte"] = std::shared_ptr<IntegerCODEC>(new MaskedVByte());
+  map["streamvbyte"] = std::shared_ptr<IntegerCODEC>(new StreamVByte());
+  map["varintgb"] = std::shared_ptr<IntegerCODEC>(new VarIntGB<>());
+  map["simple16"] = std::shared_ptr<IntegerCODEC>(new Simple16<true>());
+  map["simple9"] = std::shared_ptr<IntegerCODEC>(new Simple9<true>());
+  map["simple9_rle"] = std::shared_ptr<IntegerCODEC>(new Simple9_RLE<true>());
+  map["simple8b"] = std::shared_ptr<IntegerCODEC>(new Simple8b<true>());
+  map["simple8b_rle"] = std::shared_ptr<IntegerCODEC>(new Simple8b_RLE<true>());
+#ifdef VARINTG8IU_H__
+  map["varintg8iu"] = std::shared_ptr<IntegerCODEC>(new VarIntG8IU());
+#endif
+#ifdef USESNAPPY
+  map["snappy"] = std::shared_ptr<IntegerCODEC>(new JustSnappy());
+#endif
+  map["simdbinarypacking"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDBinaryPacking, VariableByte>());
+  map["simdgroupsimple"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDGroupSimple<false, false>, VariableByte>());
+  map["simdgroupsimple_ringbuf"] = std::shared_ptr<IntegerCODEC>(
+      new CompositeCodec<SIMDGroupSimple<true, true>, VariableByte>());
+  map["copy"] = std::shared_ptr<IntegerCODEC>(new JustCopy());
+  return map;
+}
+CodecMap CODECFactory::scodecmap = initializefactory();
+}

--- a/src/codecs.cpp
+++ b/src/codecs.cpp
@@ -727,7 +727,8 @@ void message() {
   cout << "the --codecs flag takes as an argument"
           " a comma-separated list of schemes chosen among those:"
        << endl;
-  vector<string> all = CODECFactory::allNames();
+  CODECFactory factory;
+  vector<string> all = factory.allNames();
   for (auto i = all.begin(); i != all.end(); ++i) {
     cout << *i;
     if (i + 1 == all.end())
@@ -751,8 +752,9 @@ int main(int argc, char **argv) {
   bool computeentropy = false;
 
   bool splitlongarrays = true;
+  CODECFactory factory;
   vector<shared_ptr<IntegerCODEC>> tmp =
-      CODECFactory::allSchemes(); // the default
+      factory.allSchemes(); // the default
   vector<algostats> myalgos;
   for (auto &i : tmp) {
     myalgos.push_back(algostats(i));
@@ -780,9 +782,9 @@ int main(int argc, char **argv) {
           cout << "# pretty name = " << *i << endl;
           if (i->at(0) == '@') { // SIMD
             myalgos.push_back(algostats(
-                CODECFactory::getFromName(i->substr(1, i->size() - 1)), true));
+                factory.getFromName(i->substr(1, i->size() - 1)), true));
           } else {
-            myalgos.push_back(algostats(CODECFactory::getFromName(*i)));
+            myalgos.push_back(algostats(factory.getFromName(*i)));
           }
           cout << "# added '" << myalgos.back().name() << "'" << endl;
         }

--- a/src/inmemorybenchmark.cpp
+++ b/src/inmemorybenchmark.cpp
@@ -697,7 +697,8 @@ void message(const char *prog) {
        << endl;
   cerr << "Use the --codecs flag to specify the schemes." << endl;
   cerr << " schemes include:" << endl;
-  vector<string> all = CODECFactory::allNames();
+  CODECFactory factory;
+  vector<string> all = factory.allNames();
   for (auto i = all.begin(); i != all.end(); ++i) {
     cerr << *i << endl;
   }
@@ -713,8 +714,9 @@ int main(int argc, char **argv) {
   size_t MINLENGTH = 1;
   size_t MAXLENGTH = (std::numeric_limits<uint32_t>::max)();
   size_t MAXCOUNTER = (std::numeric_limits<std::size_t>::max)();
+  CODECFactory factory;
   vector<shared_ptr<IntegerCODEC>> tmp =
-      CODECFactory::allSchemes(); // the default
+      factory.allSchemes(); // the default
   vector<algostats> myalgos;
   for (auto i = tmp.begin(); i != tmp.end(); ++i) {
     myalgos.push_back(algostats(*i));
@@ -759,9 +761,9 @@ int main(int argc, char **argv) {
           if (i->at(0) == '@') { // SIMD
             string namewithoutprefix = i->substr(1, i->size() - 1);
             myalgos.push_back(
-                algostats(CODECFactory::getFromName(namewithoutprefix), true));
+                algostats(factory.getFromName(namewithoutprefix), true));
           } else {
-            myalgos.push_back(algostats(CODECFactory::getFromName(*i)));
+            myalgos.push_back(algostats(factory.getFromName(*i)));
           }
           cout << "# added '" << myalgos.back().name() << "'" << endl;
         }

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -18,7 +18,8 @@ using namespace std;
 using namespace FastPForLib;
 
 int main() {
-  vector<shared_ptr<IntegerCODEC>> myalgos = CODECFactory::allSchemes();
+  CODECFactory factory;
+  vector<shared_ptr<IntegerCODEC>> myalgos = factory.allSchemes();
   for (uint32_t b = 0; b <= 28; ++b) {
 
     cout << "testing... b = " << b << endl;

--- a/unittest/test_fastpfor.cpp
+++ b/unittest/test_fastpfor.cpp
@@ -116,7 +116,7 @@ namespace FastPForLib {
           std::uniform_int_distribution<int32_t> dist(
                                   std::numeric_limits<int32_t>::min(),
                                   std::numeric_limits<int32_t>::max());
-          for (int i = 0; i < values; ++i) {
+          for (uint32_t i = 0; i < values; ++i) {
             v.push_back(dist(e2));
           }
         }
@@ -127,7 +127,7 @@ namespace FastPForLib {
           std::uniform_int_distribution<int64_t> dist(
                                   std::numeric_limits<int64_t>::min(),
                                   std::numeric_limits<int64_t>::max());
-          for (int i = 0; i < values; ++i) {
+          for (uint32_t i = 0; i < values; ++i) {
             v.push_back(dist(e2));
           }
         }


### PR DESCRIPTION
Some users include multiple versions of CODECFactory in their projects. This is almost surely a sign of unsafe code. You should have at most one CODECFactory  per project. Nevertheless, let us make it a bit cleaner by using a source file.

Plus some random pedantic fixes.

Simpler fix than https://github.com/lemire/FastPFor/pull/91 where a member reference to a static function variable was used.