### PR TITLE
Replace std::iostream use with stdio in FastPFor lib

### DIFF
--- a/headers/common.h
+++ b/headers/common.h
@@ -31,8 +31,6 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
-#include <iomanip>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <numeric>
@@ -50,7 +48,6 @@
 
 #define __attribute__(n)
 #define __restrict__ __restrict
-
 #endif
 
 #endif /* COMMON_H_ */

--- a/headers/deltautil.h
+++ b/headers/deltautil.h
@@ -9,6 +9,8 @@
 #define DELTAUTIL_H_
 #include <vector>
 #include <exception>
+#include <iostream>
+#include <iomanip>
 #include "common.h"
 #include "codecs.h"
 #include "memutil.h"

--- a/headers/fastpfor.h
+++ b/headers/fastpfor.h
@@ -406,14 +406,13 @@ public:
     }
     assert(out == nvalue + initout);
     if (oldnvalue < nvalue)
-      std::cerr
-          << "It is possible we have a buffer overrun. You reported having allocated "
-          << oldnvalue * sizeof(uint32_t)
-          << " bytes for the compressed data but we needed "
-          << nvalue * sizeof(uint32_t)
-          << " bytes. Please increase the available memory"
-              " for compressed data or check the value of the last parameter provided "
-              " to the encodeArray method." << std::endl;
+      fprintf(stderr,
+          "It is possible we have a buffer overrun. You reported having allocated "
+          "%zu bytes for the compressed data but we needed "
+          "%zu bytes. Please increase the available memory "
+          "for compressed data or check the value of the last parameter provided "
+          "to the encodeArray method.\n",
+          oldnvalue * sizeof(uint32_t), nvalue * sizeof(uint32_t));
   }
 
   void getBestBFromData(const uint32_t *in, uint8_t &bestb,

--- a/headers/maropuparser.h
+++ b/headers/maropuparser.h
@@ -9,6 +9,7 @@
 #define MAROPUPARSER_H_
 
 #include "common.h"
+#include <iostream>
 
 namespace FastPForLib {
 

--- a/headers/newpfor.h
+++ b/headers/newpfor.h
@@ -242,7 +242,7 @@ void NewPFor<BlockSizeInUnitsOfPackSize, ExceptionCoder>::encodeArray(
   }
 #ifdef STATS
   for (uint32_t k = 0; k < 33; ++k)
-    cout << "newpfor b=" << k << " " << stats[k] << endl;
+    std::cout << "newpfor b=" << k << " " << stats[k] << std::endl;
 #endif
   if (nvalue > initnvalue) {
     std::cerr << " we have a possible buffer overrun" << std::endl;

--- a/headers/newpfor.h
+++ b/headers/newpfor.h
@@ -242,14 +242,15 @@ void NewPFor<BlockSizeInUnitsOfPackSize, ExceptionCoder>::encodeArray(
   }
 #ifdef STATS
   for (uint32_t k = 0; k < 33; ++k)
-    std::cout << "newpfor b=" << k << " " << stats[k] << std::endl;
+    printf("newpfor b=%u %u\n", k, stats[k]);
 #endif
   if (nvalue > initnvalue) {
-    std::cerr << " we have a possible buffer overrun" << std::endl;
+    fprintf(stderr, "we have a possible buffer overrun\n");
   }
-  ASSERT(len == static_cast<size_t>(in - initin), len << " " << (in - initin));
+  ASSERT(len == static_cast<size_t>(in - initin),
+      std::to_string(len) + " " + std::to_string(in - initin));
   ASSERT(nvalue == static_cast<size_t>(out - initout),
-         nvalue << " " << (out - initout));
+      std::to_string(nvalue) + " " + std::to_string(out - initout));
 }
 
 template <uint32_t BlockSizeInUnitsOfPackSize, class ExceptionCoder>
@@ -310,9 +311,10 @@ NewPFor<BlockSizeInUnitsOfPackSize, ExceptionCoder>::decodeArray(
   }
 
   if (static_cast<size_t>(out - initout) > nvalue) {
-    std::cerr << "possible buffer overrun" << std::endl;
+    fprintf(stderr, "possible buffer overrun\n");
   }
-  ASSERT(in <= len + initin, in - initin << " " << len);
+  ASSERT(in <= len + initin,
+      std::to_string(in - initin) + " " + std::to_string(len));
 
   nvalue = out - initout;
   assert(nvalue == numBlocks * BlockSize);

--- a/headers/simdfastpfor.h
+++ b/headers/simdfastpfor.h
@@ -209,15 +209,14 @@ public:
       in += thissize;
     }
     assert(out == nvalue + initout);
-		if (oldnvalue < nvalue)
-			std::cerr
-					<< "It is possible we have a buffer overrun. You reported having allocated "
-					<< oldnvalue * sizeof(uint32_t)
-					<< " bytes for the compressed data but we needed "
-					<< nvalue * sizeof(uint32_t)
-					<< " bytes. Please increase the available memory"
-							" for compressed data or check the value of the last parameter provided "
-							" to the encodeArray method." << std::endl;
+    if (oldnvalue < nvalue)
+      fprintf(stderr,
+          "It is possible we have a buffer overrun. You reported having allocated "
+          "%zu bytes for the compressed data but we needed "
+          "%zu bytes. Please increase the available memory "
+          "for compressed data or check the value of the last parameter provided "
+          "to the encodeArray method.\n",
+          oldnvalue * sizeof(uint32_t), nvalue * sizeof(uint32_t));
     resetBuffer(); // if you don't do this, the buffer has a memory
   }
 
@@ -444,14 +443,13 @@ public:
     }
     assert(out == nvalue + initout);
     if (oldnvalue < nvalue)
-			std::cerr
-					<< "It is possible we have a buffer overrun. You reported having allocated "
-					<< oldnvalue * sizeof(uint32_t)
-					<< " bytes for the compressed data but we needed "
-					<< nvalue * sizeof(uint32_t)
-					<< " bytes. Please increase the available memory"
-							" for compressed data or check the value of the last parameter provided "
-							" to the encodeArray method." << std::endl;
+      fprintf(stderr,
+          "It is possible we have a buffer overrun. You reported having allocated "
+          "%zu bytes for the compressed data but we needed "
+          "%zu bytes. Please increase the available memory "
+          "for compressed data or check the value of the last parameter provided "
+          "to the encodeArray method.\n",
+          oldnvalue * sizeof(uint32_t), nvalue * sizeof(uint32_t));
   }
 
   void getBestBFromData(const uint32_t *in, uint8_t &bestb,

--- a/headers/simdnewpfor.h
+++ b/headers/simdnewpfor.h
@@ -220,14 +220,15 @@ void SIMDNewPFor<BlockSizeInUnitsOfPackSize, ExceptionCoder>::encodeArray(
   }
 #ifdef STATS
   for (uint32_t k = 0; k < 33; ++k)
-    std::cout << "simdnewpfor b=" << k << " " << stats[k] << std::endl;
+    printf("simdnewpfor b=%u %u\n", k, stats[k]);
 #endif
   if (nvalue > initnvalue) {
-    std::cerr << " we have a possible buffer overrun" << std::endl;
+    fprintf(stderr, "we have a possible buffer overrun\n");
   }
-  ASSERT(len == static_cast<size_t>(in - initin), len << " " << (in - initin));
+  ASSERT(len == static_cast<size_t>(in - initin),
+      std::to_string(len) + " " + std::to_string(in - initin));
   ASSERT(nvalue == static_cast<size_t>(out - initout),
-         nvalue << " " << (out - initout));
+      std::to_string(nvalue) + " " + std::to_string(out - initout));
 }
 
 template <uint32_t BlockSizeInUnitsOfPackSize, class ExceptionCoder>
@@ -277,9 +278,10 @@ SIMDNewPFor<BlockSizeInUnitsOfPackSize, ExceptionCoder>::decodeArray(
     }
   }
   if (static_cast<size_t>(out - initout) > nvalue) {
-    std::cerr << "possible buffer overrun" << std::endl;
+    fprintf(stderr, "possible buffer overrun\n");
   }
-  ASSERT(in <= len + initin, in - initin << " " << len);
+  ASSERT(in <= len + initin,
+      std::to_string(in - initin) + " " + std::to_string(len));
 
   nvalue = out - initout;
   assert(nvalue == numBlocks * BlockSize);

--- a/headers/simdnewpfor.h
+++ b/headers/simdnewpfor.h
@@ -220,7 +220,7 @@ void SIMDNewPFor<BlockSizeInUnitsOfPackSize, ExceptionCoder>::encodeArray(
   }
 #ifdef STATS
   for (uint32_t k = 0; k < 33; ++k)
-    cout << "simdnewpfor b=" << k << " " << stats[k] << endl;
+    std::cout << "simdnewpfor b=" << k << " " << stats[k] << std::endl;
 #endif
   if (nvalue > initnvalue) {
     std::cerr << " we have a possible buffer overrun" << std::endl;

--- a/headers/simple16.h
+++ b/headers/simple16.h
@@ -728,8 +728,8 @@ const uint32_t *Simple16<MarkLength>::decodeArray(const uint32_t *in,
     std::cerr << " possible overrun" << std::endl;
   nvalue = actualvalue;
 #ifdef STATS
-  cout << "simple16 decode " << len << endl;
-  vector<uint32_t> stats(16, 0);
+  std::cout << "simple16 decode " << len << std::endl;
+  std::vector<uint32_t> stats(16, 0);
 #endif
   const uint32_t *const end = out + nvalue;
   while (end > out) {
@@ -742,7 +742,7 @@ const uint32_t *Simple16<MarkLength>::decodeArray(const uint32_t *in,
 #ifdef STATS
   uint32_t sum = std::accumulate(stats.begin(), stats.end(), 0);
   for (uint32_t k = 0; k < stats.size(); ++k) {
-    cout << "simple16 stats[" << k << "]=" << stats[k] * 1.0 / sum << endl;
+    std::cout << "simple16 stats[" << k << "]=" << stats[k] * 1.0 / sum << std::endl;
   }
 #endif
   ASSERT(in <= endin, in - endin);

--- a/headers/simple16.h
+++ b/headers/simple16.h
@@ -376,7 +376,7 @@ void Simple16<MarkLength>::encodeArray(const uint32_t *in, const size_t length,
         assert(which(out) == 14);
     } else {
       if ((*in >> 28) > 0) {
-        std::cerr << "Input's out of range: " << *in << std::endl;
+        fprintf(stderr, "Input's out of range: %u\n", *in);
         throw std::runtime_error(
             "You tried to apply Simple16 to an incompatible set of integers: they should be in [0,2^28).");
       }
@@ -617,7 +617,7 @@ void Simple16<MarkLength>::encodeArray(const uint32_t *in, const size_t length,
         assert(which(out) == 14);
     } else {
       if ((*in >> 28) > 0) {
-        std::cerr << "Input's out of range: " << *in << std::endl;
+        fprintf(stderr, "Input's out of range: %u\n", *in);
         throw std::runtime_error(
             "You tried to apply Simple16 to an incompatible set of integers.");
       }
@@ -725,10 +725,10 @@ const uint32_t *Simple16<MarkLength>::decodeArray(const uint32_t *in,
   const uint32_t actualvalue =
       MarkLength ? *(in++) : static_cast<uint32_t>(nvalue);
   if (nvalue < actualvalue)
-    std::cerr << " possible overrun" << std::endl;
+    fprintf(stderr, "possible overrun\n");
   nvalue = actualvalue;
 #ifdef STATS
-  std::cout << "simple16 decode " << len << std::endl;
+  printf("simple16 decode %zu\n", len);
   std::vector<uint32_t> stats(16, 0);
 #endif
   const uint32_t *const end = out + nvalue;
@@ -742,10 +742,10 @@ const uint32_t *Simple16<MarkLength>::decodeArray(const uint32_t *in,
 #ifdef STATS
   uint32_t sum = std::accumulate(stats.begin(), stats.end(), 0);
   for (uint32_t k = 0; k < stats.size(); ++k) {
-    std::cout << "simple16 stats[" << k << "]=" << stats[k] * 1.0 / sum << std::endl;
+    printf("simple16 stats[%u]=%f\n", k, stats[k] * 1.0 / sum);
   }
 #endif
-  ASSERT(in <= endin, in - endin);
+  ASSERT(in <= endin, std::to_string(in - endin));
   return in;
 }
 

--- a/headers/simple8b.h
+++ b/headers/simple8b.h
@@ -421,7 +421,7 @@ void Simple8b<MarkLength>::encodeArray(const uint32_t *in, const size_t length,
     }
     if (becareful)
       ASSERT(initin + length - ValuesRemaining + NumberOfValuesCoded == in,
-             which(out64));
+          std::to_string(which(out64)));
     ++out64;
 
     ValuesRemaining -= NumberOfValuesCoded;
@@ -512,7 +512,7 @@ const uint32_t *Simple8b<MarkLength>::decodeArray(const uint32_t *in,
 #endif
 
   if (nvalue < actualvalue)
-    std::cerr << " possible overrun" << std::endl;
+    fprintf(stderr, "possible overrun\n");
   nvalue = actualvalue;
   const uint32_t *const end = out + nvalue;
   const uint32_t *const initout(out);
@@ -634,14 +634,14 @@ const uint32_t *Simple8b<MarkLength>::decodeArray(const uint32_t *in,
 #ifdef STATS
   uint32_t sum = std::accumulate(stats.begin(), stats.end(), 0);
   for (uint32_t k = 0; k < stats.size(); ++k) {
-    std::cout << "simple8b stats[" << k << "]=" << stats[k] * 1.0 / sum << std::endl;
+    printf("simple8b stats[%u]=%f\n", k, stats[k] * 1.0 / sum);
   }
 #endif
   assert(in64 <= finalin64);
   in = reinterpret_cast<const uint32_t *>(in64);
   assert(in <= endin);
   // check that we don't overrun the buffer too much?
-  ASSERT(out < end + 240, out - end);
+  ASSERT(out < end + 240, std::to_string(out - end));
   nvalue = MarkLength ? actualvalue : out - initout;
   return in;
 }

--- a/headers/simple8b.h
+++ b/headers/simple8b.h
@@ -495,7 +495,7 @@ const uint32_t *Simple8b<MarkLength>::decodeArray(const uint32_t *in,
   const uint32_t *const endin(in + len);
 #endif
 #ifdef STATS
-  vector<uint32_t> stats(16, 0);
+  std::vector<uint32_t> stats(16, 0);
 #endif
   uint32_t markednvalue;
   if (MarkLength) {
@@ -634,7 +634,7 @@ const uint32_t *Simple8b<MarkLength>::decodeArray(const uint32_t *in,
 #ifdef STATS
   uint32_t sum = std::accumulate(stats.begin(), stats.end(), 0);
   for (uint32_t k = 0; k < stats.size(); ++k) {
-    cout << "simple8b stats[" << k << "]=" << stats[k] * 1.0 / sum << std::endl;
+    std::cout << "simple8b stats[" << k << "]=" << stats[k] * 1.0 / sum << std::endl;
   }
 #endif
   assert(in64 <= finalin64);

--- a/headers/simple8b_rle.h
+++ b/headers/simple8b_rle.h
@@ -290,7 +290,7 @@ public:
     const uint64_t *finalin64 = reinterpret_cast<const uint64_t *>(endin);
 #endif
     if (nvalue < actualvalue) {
-      std::cerr << " possible overrun" << std::endl;
+      fprintf(stderr, "possible overrun\n");
     }
     nvalue = actualvalue;
 

--- a/headers/simple9.h
+++ b/headers/simple9.h
@@ -281,7 +281,7 @@ const uint32_t *
 Simple9<MarkLength, hacked>::decodeArray(const uint32_t *in, const size_t len,
                                          uint32_t *out, size_t &nvalue) {
   size_t lengths[] = {28, 14, 9, 7, 5, 4, 3, 2, 1};
-  vector<uint32_t> stats(16, 0);
+  std::vector<uint32_t> stats(16, 0);
   size_t expectedlength = 0;
 #else
 template <bool MarkLength, bool hacked>

--- a/headers/simple9.h
+++ b/headers/simple9.h
@@ -167,7 +167,7 @@ void Simple9<MarkLength, hacked>::encodeArray(const uint32_t *in,
         assert(which(out) == 14);
     } else {
       if ((*in >> 28) > 0) {
-        std::cerr << "Input's out of range: " << *in << std::endl;
+        fprintf(stderr, "Input's out of range: %u\n", *in);
         throw std::runtime_error(
             "You tried to apply Simple9 to an incompatible set of integers.");
       }
@@ -260,7 +260,7 @@ void Simple9<MarkLength, hacked>::encodeArray(const uint32_t *in,
         assert(which(out) == 14);
     } else {
       if ((*in >> 28) > 0) {
-        std::cerr << "Input's out of range: " << *in << std::endl;
+        fprintf(stderr, "Input's out of range: %u\n", *in);
         throw std::runtime_error(
             "You tried to apply Simple9 to an incompatible set of integers.");
       }
@@ -294,7 +294,7 @@ Simple9<MarkLength, hacked>::decodeArray(const uint32_t *in, const size_t /* len
       throw NotEnoughStorage(*in);
   const uint32_t actualvalue = MarkLength ? *(in++) : nvalue;
   if (nvalue < actualvalue)
-    std::cerr << " possible overrun" << std::endl;
+    fprintf(stderr, "possible overrun\n");
   nvalue = actualvalue;
   const uint32_t *const end = out + nvalue;
   while (end > out) {
@@ -310,14 +310,11 @@ Simple9<MarkLength, hacked>::decodeArray(const uint32_t *in, const size_t /* len
   uint32_t sum = std::accumulate(stats.begin(), stats.end(), 0);
 
   for (uint32_t k = 0; k < stats.size(); ++k) {
-    std::cout << "k=" << k << std::endl;
-    std::cout << "simple9 stats[" << k << "]=" << (stats[k] * 1.0 / sum)
-              << std::endl;
+    printf("simple9 stats[k=%u]=%f\n", k, stats[k] * 1.0 / sum);
   }
-  std::cout << "alt computed length" << sum << std::endl;
-  std::cout << "computed length = " << expectedlength << std::endl;
-  std::cout << "we compressed " << nvalue << " integers down to " << len
-            << " 32-bit words" << std::endl;
+  printf("alt computed length %u\n", sum);
+  printf("computed length = %zu\n", expectedlength);
+  printf("we compressed %zu integers down to %zu 32-bit words\n", nvalue, len);
 #endif
   return in;
 }

--- a/headers/simple9_rle.h
+++ b/headers/simple9_rle.h
@@ -286,7 +286,7 @@ public:
     }
     const size_t actualvalue = MarkLength ? markednvalue : nvalue;
     if (nvalue < actualvalue) {
-      std::cerr << " possible overrun" << std::endl;
+      fprintf(stderr, "possible overrun\n");
     }
     auto count = actualvalue;
     Simple9_Codec::Decompress(input, 0, out, 0, count);

--- a/headers/util.h
+++ b/headers/util.h
@@ -19,17 +19,17 @@ namespace FastPForLib {
 //#define STATS
 // taken from stackoverflow
 #ifndef NDEBUG
-#define ASSERT(condition, message)                                             \
-  do {                                                                         \
-    if (!(condition)) {                                                        \
-      std::cerr << "Assertion `" #condition "` failed in " << __FILE__         \
-                << " line " << __LINE__ << ": " << message << std::endl;       \
-      std::exit(EXIT_FAILURE);                                                 \
-    }                                                                          \
+#define ASSERT(condition, message) /* message is an std::string */  \
+  do {                                                              \
+    if (!(condition)) {                                             \
+      fprintf(stderr, "Assertion `%s` failed in %s line %d : %s\n", \
+        #condition, __FILE__, __LINE__, (message).c_str());         \
+      std::exit(EXIT_FAILURE);                                      \
+    }                                                               \
   } while (false)
 #else
-#define ASSERT(condition, message)                                             \
-  do {                                                                         \
+#define ASSERT(condition, message)                                  \
+  do {                                                              \
   } while (false)
 #endif
 
@@ -178,12 +178,6 @@ inline void checkifdivisibleby(size_t a, uint32_t x) {
                     + std::to_string(x);
     throw std::logic_error(msg);
   }
-}
-
-template <class iter> void printme(iter i, iter b) {
-  for (iter j = i; j != b; ++j)
-    std::cout << *j << " ";
-  std::cout << std::endl;
 }
 
 __attribute__((const)) inline uint32_t asmbits(const uint32_t v) {
@@ -416,7 +410,7 @@ public:
     if (sum == 0)
       return;
     for (size_t k = 0; k < histo.size(); ++k) {
-      std::cout << prefix << k << " " << histo[k] / sum << std::endl;
+      printf("%s%zu %f\n", prefix.c_str(), k, histo[k] / sum);
     }
   }
   template <class container> void eatIntegers(const container &rawdata) {

--- a/headers/vsencoding.h
+++ b/headers/vsencoding.h
@@ -158,7 +158,7 @@ inline uint32_t *VSEncoding::compute_OptPartition(uint32_t *seq, uint32_t len,
   cost = new uint64_t[len + 1];
 
   if (SSSP == NULL || cost == NULL)
-    std::cerr << "Can't allocate memory" << std::endl;
+    fprintf(stderr, "Can't allocate memory\n");
 
   for (i = 0; i < len + 1U; ++i) {
     SSSP[i] = -1;
@@ -455,7 +455,7 @@ inline void VSEncodingBlocks::encodeVS(uint32_t len, const uint32_t *in,
   logs = new uint32_t[len];
 
   if (logs == NULL)
-    std::cerr << "Can't allocate memory" << std::endl;
+    fprintf(stderr, "Can't allocate memory\n");
 
   /* Compute logs of all numbers */
   for (i = 0; i < len; i++)
@@ -469,7 +469,7 @@ inline void VSEncodingBlocks::encodeVS(uint32_t len, const uint32_t *in,
   wt = new BitsWriter(out);
 
   if (wt == NULL)
-    std::cerr << "Can't initialize a class" << std::endl;
+    fprintf(stderr, "Can't initialize a class\n");
 
   /* countBlocksLogs[i] says how many blocks uses i bits */
   for (i = 0; i < VSEBLOCKS_LOGS_LEN; i++) {
@@ -508,7 +508,7 @@ inline void VSEncodingBlocks::encodeVS(uint32_t len, const uint32_t *in,
       blocks[i] = new uint32_t[countBlocksLogs[i]];
 
       if (blocks[i] == NULL)
-        std::cerr << "Can't allocate memory" << std::endl;
+        fprintf(stderr, "Can't allocate memory\n");
     } else {
       blocks[i] = NULL;
     }
@@ -707,8 +707,8 @@ inline void VSEncodingBlocks::encodeArray(const uint32_t *in, const size_t len,
   lout += csize;
   nvalue += csize;
   ++nvalue;
-  ASSERT(nvalue + initout == lout, (lout - initout) << " " << nvalue << " "
-                                                    << csize);
+  ASSERT(nvalue + initout == lout,
+    std::to_string(lout - initout) + " " + std::to_string(nvalue) + " " + std::to_string(csize));
 }
 
 inline const uint32_t *VSEncodingBlocks::decodeArray(const uint32_t *in,
@@ -742,7 +742,7 @@ inline const uint32_t *VSEncodingBlocks::decodeArray(const uint32_t *in,
   const uint32_t *ans = decodeVS(res, in, out, &__tmp[0]);
   assert(initin + len >= in);
   if (initout + orignvalue < out)
-    std::cerr << "possible overrun" << std::endl;
+    fprintf(stderr, "possible overrun\n");
   return ans;
 }
 

--- a/headers/ztimer.h
+++ b/headers/ztimer.h
@@ -30,7 +30,7 @@ struct qpc_clock {
   typedef std::chrono::time_point<qpc_clock, duration> time_point;
   static time_point now() {
     static bool isInited = false;
-    static LARGE_INTEGER frequency = {0, 0};
+    static LARGE_INTEGER frequency = {{0, 0}};
     if (!isInited) {
       if (QueryPerformanceFrequency(&frequency) == 0) {
         throw std::logic_error("QueryPerformanceCounter not supported: " +

--- a/src/codecfactory.cpp
+++ b/src/codecfactory.cpp
@@ -47,13 +47,12 @@ std::vector<std::string> CODECFactory::allNames() {
 
 std::shared_ptr<IntegerCODEC> &CODECFactory::getFromName(std::string name) {
   if (scodecmap.find(name) == scodecmap.end()) {
-    std::cerr << "name " << name << " does not refer to a CODEC." << std::endl;
-    std::cerr << "possible choices:" << std::endl;
+    fprintf(stderr, "name %s does not refer to a CODEC.\n"
+                    "possible choices:\n", name.c_str());
     for (auto i = scodecmap.begin(); i != scodecmap.end(); ++i) {
-      std::cerr << static_cast<std::string>(i->first)
-                << std::endl; // useless cast, but just to be clear
+      fprintf(stderr, "%s\n", i->first.c_str());
     }
-    std::cerr << "for now, I'm going to just return 'copy'" << std::endl;
+    fprintf(stderr, "for now, I'm going to just return 'copy'\n");
     return scodecmap["copy"];
   }
   return scodecmap[name];

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -5,6 +5,7 @@
  * (c) Daniel Lemire, http://lemire.me/en/
  */
 #include <memory>
+#include <iostream>
 #include <iomanip>
 #include <time.h>
 #include "codecfactory.h"


### PR DESCRIPTION
`Fix missing std:: when STATS enabled` is a simple fix.

`Replace std::iostream use with stdio in FastPFor lib` - is a good change imo, but it may have issues.
All uses of std::cout/cerr were replaced with printf, and even if the changes didn't introduce errors ([please double check](https://github.com/lemire/FastPFor/pull/96/commits/71b042513f6a65b3be3d6cd0622bd431f286f496)), there might be issues with printf modifiers with old compilers. For example, `%zu` is [available starting from VS2013](https://stackoverflow.com/a/44055215/468725). In any case, that's a 10-year old version of VS