### PR TITLE
Add missing simple16.h header

### DIFF
--- a/headers/newpfor.h
+++ b/headers/newpfor.h
@@ -18,6 +18,7 @@
 #include "common.h"
 #include "util.h"
 #include "codecs.h"
+#include "simple16.h"
 
 namespace FastPForLib {
 

--- a/headers/simdnewpfor.h
+++ b/headers/simdnewpfor.h
@@ -20,6 +20,7 @@
 #include "util.h"
 #include "codecs.h"
 #include "newpfor.h"
+#include "simple16.h"
 #include "usimdbitpacking.h"
 
 namespace FastPForLib {


### PR DESCRIPTION
Both NewPFor and SIMDNewPFor classes reference Simple16, which is defined in simple16.h header