### PR TITLE
fix build as a cmake subproject

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -6,8 +6,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
     GIT_TAG main
-    SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
-    BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
+    SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+    BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""


### PR DESCRIPTION
Hi,

I tried to include this in another project using

```
add_subdirectory(deps/fastpfor)
```

I was not able to build this because the googletest-src directory was placed in the binary dir of the main project. This changes fixes this issue.