### PR TITLE
Avoid potentially uninitialized local variable warning

### DIFF
--- a/headers/simdgroupsimple.h
+++ b/headers/simdgroupsimple.h
@@ -1292,7 +1292,7 @@ namespace FastPForLib {
                 // Step 2: Determine the next selector.
                 pos = 0;
                 uint8_t i;
-                uint8_t n;
+                uint8_t n = 0;
                 for (i = 0; i <= 9; i++) {
                     n = tableNum[i];
                     const uint32_t mask = tableMask[i];


### PR DESCRIPTION
When compiling in VS2022 with /W4 compiler warns that potentially uninitialized local variable 'n' used. This fixes the warning