### PR TITLE
Fix x86 build with msvc compiler

### DIFF
--- a/headers/common.h
+++ b/headers/common.h
@@ -50,7 +50,7 @@
 #include <iso646.h>
 #include <stdint.h>
 
-#if (defined(_M_X64) || defined(_M_AMD64))
+#if (defined(_M_IX86) || defined(_M_AMD64))
 #include <intrin.h>
 #elif defined(_M_ARM64)
 #include <simde/x86/sse4.1.h>

--- a/headers/cpubenchmark.h
+++ b/headers/cpubenchmark.h
@@ -42,7 +42,7 @@ static __inline__ unsigned long long stopRDTSCP(void) {
                  "%rdx");
   return (static_cast<unsigned long long>(cycles_high) << 32) | cycles_low;
 }
-#elif  (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))
+#elif (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64)))
 
 static inline unsigned long long startRDTSC(void) { return __rdtsc(); }
 

--- a/headers/simdgroupsimple.h
+++ b/headers/simdgroupsimple.h
@@ -152,7 +152,7 @@ namespace FastPForLib {
          * efficiency is not that crucial here.
          */
 
-#if (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)))  || (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))
+#if (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))) || (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64)))
 
         inline static void comprIncompleteBlock(const uint8_t &n, const __m128i *&in,
                                                 __m128i *&out) {
@@ -627,7 +627,7 @@ namespace FastPForLib {
          * efficiency is not that crucial here.
          */
 
-#if (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)))  || (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))
+#if (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))) || (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64)))
 
         inline static void decomprIncompleteBlock(const uint8_t &n,
                                                   const __m128i *&in,

--- a/src/simdbitpacking.cpp
+++ b/src/simdbitpacking.cpp
@@ -8930,7 +8930,7 @@ static void __SIMD_fastunpack1_32(const __m128i *__restrict__ in,
   __m128i InReg2 = InReg1;
   __m128i OutReg1, OutReg2, OutReg3, OutReg4;
   const __m128i mask = _mm_set1_epi32(1);
-#if defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)) || (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))
+#if (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))) || (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64)))
   unsigned shift = 0;
 
   for (unsigned i = 0; i < 8; ++i) {

--- a/src/simdunalignedbitpacking.cpp
+++ b/src/simdunalignedbitpacking.cpp
@@ -8930,7 +8930,7 @@ static void __SIMD_fastunpack1_32(const __m128i *__restrict__ in,
   __m128i InReg2 = InReg1;
   __m128i OutReg1, OutReg2, OutReg3, OutReg4;
   const __m128i mask = _mm_set1_epi32(1);
-#if (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__)))  || (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))
+#if (defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))) || (defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64)))
   unsigned shift = 0;
 
   for (unsigned i = 0; i < 8; ++i) {

--- a/src/streamvbyte.c
+++ b/src/streamvbyte.c
@@ -6,31 +6,31 @@
 // no particular alignment is assumed or guaranteed for any elements
 
 #if defined(_MSC_VER)
-     /* Microsoft C/C++-compatible compiler */
-      #if (defined(_M_X64) || defined(_M_AMD64))
-      #include <intrin.h>
-      #elif defined(_M_ARM64)
-      #include <simde/x86/sse4.1.h>
-      #endif
+    /* Microsoft C/C++-compatible compiler */
+    #if (defined(_M_IX86) || defined(_M_AMD64))
+    #include <intrin.h>
+    #elif defined(_M_ARM64)
+    #include <simde/x86/sse4.1.h>
+    #endif
 
-     #include <iso646.h>
-     #include <stdint.h>
-     #define __restrict__ __restrict
+    #include <iso646.h>
+    #include <stdint.h>
+    #define __restrict__ __restrict
 #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
-     /* GCC-compatible compiler, targeting x86/x86-64 */
-     #include <x86intrin.h>
+    /* GCC-compatible compiler, targeting x86/x86-64 */
+    #include <x86intrin.h>
 #elif defined(__aarch64__)
-     /* GCC-compatible compiler, targeting ARM with NEON */
-     #include <simde/x86/sse4.1.h>
+    /* GCC-compatible compiler, targeting ARM with NEON */
+    #include <simde/x86/sse4.1.h>
 #elif defined(__GNUC__) && defined(__IWMMXT__)
-     /* GCC-compatible compiler, targeting ARM with WMMX */
-     #include <mmintrin.h>
+    /* GCC-compatible compiler, targeting ARM with WMMX */
+    #include <mmintrin.h>
 #elif (defined(__GNUC__) || defined(__xlC__)) && (defined(__VEC__) || defined(__ALTIVEC__))
-     /* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
-     #include <altivec.h>
+    /* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
+    #include <altivec.h>
 #elif defined(__GNUC__) && defined(__SPE__)
-     /* GCC-compatible compiler, targeting PowerPC with SPE */
-     #include <spe.h>
+    /* GCC-compatible compiler, targeting PowerPC with SPE */
+    #include <spe.h>
 #endif
 
 #include <stdint.h>

--- a/src/varintdecode.c
+++ b/src/varintdecode.c
@@ -5,27 +5,27 @@
 
 #if defined(_MSC_VER)
      /* Microsoft C/C++-compatible compiler */
-    #if (defined(_M_X64) || defined(_M_AMD64))
+    #if (defined(_M_IX86) || defined(_M_AMD64))
     #include <intrin.h>
     #elif defined(_M_ARM64)
     #include <simde/x86/sse4.1.h>
     #endif
 #elif defined(__GNUC__) && (defined(__x86_64__) || defined(__i386__))
-     /* GCC-compatible compiler, targeting x86/x86-64 */
-     #include <x86intrin.h>
+    /* GCC-compatible compiler, targeting x86/x86-64 */
+    #include <x86intrin.h>
 
 #elif defined(__aarch64__)
-     /* GCC-compatible compiler, targeting ARM with NEON */
-     #include <simde/x86/sse4.1.h>
+    /* GCC-compatible compiler, targeting ARM with NEON */
+    #include <simde/x86/sse4.1.h>
 #elif defined(__GNUC__) && defined(__IWMMXT__)
-     /* GCC-compatible compiler, targeting ARM with WMMX */
-     #include <mmintrin.h>
+    /* GCC-compatible compiler, targeting ARM with WMMX */
+    #include <mmintrin.h>
 #elif (defined(__GNUC__) || defined(__xlC__)) && (defined(__VEC__) || defined(__ALTIVEC__))
-     /* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
-     #include <altivec.h>
+    /* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
+    #include <altivec.h>
 #elif defined(__GNUC__) && defined(__SPE__)
-     /* GCC-compatible compiler, targeting PowerPC with SPE */
-     #include <spe.h>
+    /* GCC-compatible compiler, targeting PowerPC with SPE */
+    #include <spe.h>
 #endif
 #include <stdint.h>
 


### PR DESCRIPTION
Replace check for _M_X64 with _M_IX86 to make sure x86 builds can be compiled