### PR TITLE
skip the CMAKE_MODULE_PATH var, directly using full path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(PROJECT_DESCRIPTION "The FastPFOR C++ library: Fast integer compression")
 set(PROJECT_VERSION "0.1.9")
 
 include(DetectCPUFeatures)
-include("${CMAKE_MODULE_PATH}/environment.cmake")
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/environment.cmake")
 
 
 message("Building for architecture: ${CMAKE_SYSTEM_PROCESSOR}")


### PR DESCRIPTION
this is a way to avoid cmake configure failed while using FastPFor as a submodule.