### PR TITLE
Clear trailing bytes in StreamVByte to ensure bit-exact output

### DIFF
--- a/headers/streamvariablebyte.h
+++ b/headers/streamvariablebyte.h
@@ -51,6 +51,8 @@ public:
                                 count, std::numeric_limits<uint32_t>::max())),
         0, 1);
     nvalue = static_cast<size_t>(bytesWritten + 3) / 4;
+    for (size_t i = bytesWritten; i < nvalue * 4; ++i)
+      reinterpret_cast<uint8_t*>(out)[i] = 0;
   }
 
   const uint32_t *decodeArray(const uint32_t *in, const size_t /* count */,


### PR DESCRIPTION
StreamVByte codec rounds up output size to multiple of 4 bytes. As a result, up to 3 trailing bytes could be uninitialized memory passed to the encodeArray function. To ensure bitexact output, these padding bytes should be cleared.