### PR TITLE
Make googletest optional (default ON)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,64 +167,65 @@ else()
     target_link_libraries(inmemorybenchmarksnappy FastPFOR ${snappy_LIBRARIES})
 endif()
 
-# Download and unpack googletest at configure time
-configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
-endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "Build step for googletest failed: ${result}")
-endif()
+option(WITH_TEST "Build with Google Test" ON)
 
-# Prevent GoogleTest from overriding our compiler/linker options
-# when building with Visual Studio
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+if(WITH_TEST)
+  # Download and unpack googletest at configure time
+  configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  endif()
 
-# Add googletest directly to our build. This adds
-# the following targets: gtest, gtest_main, gmock
-# and gmock_main
-add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
-                 EXCLUDE_FROM_ALL)
+  # Prevent GoogleTest from overriding our compiler/linker options
+  # when building with Visual Studio
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-# The gtest/gmock targets carry header search path
-# dependencies automatically when using CMake 2.8.11 or
-# later. Otherwise we have to add them here ourselves.
-if(CMAKE_VERSION VERSION_LESS 2.8.11)
-    include_directories("${gtest_SOURCE_DIR}/include"
-                        "${gmock_SOURCE_DIR}/include")
-endif()
+  # Add googletest directly to our build. This adds
+  # the following targets: gtest, gtest_main, gmock
+  # and gmock_main
+  add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                   ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                   EXCLUDE_FROM_ALL)
 
-add_executable(codecs src/codecs.cpp)
-target_link_libraries(codecs FastPFOR)
+  # The gtest/gmock targets carry header search path
+  # dependencies automatically when using CMake 2.8.11 or
+  # later. Otherwise we have to add them here ourselves.
+  if(CMAKE_VERSION VERSION_LESS 2.8.11)
+      include_directories("${gtest_SOURCE_DIR}/include"
+                          "${gmock_SOURCE_DIR}/include")
+  endif()
 
-add_executable(example example.cpp)
-target_link_libraries(example FastPFOR)
+  add_executable(codecs src/codecs.cpp)
+  target_link_libraries(codecs FastPFOR)
 
-add_executable(inmemorybenchmark src/inmemorybenchmark.cpp)
-target_link_libraries(inmemorybenchmark FastPFOR)
+  add_executable(example example.cpp)
+  target_link_libraries(example FastPFOR)
 
-add_executable(unit src/unit.cpp)
-target_link_libraries(unit FastPFOR)
-add_custom_target(check unit DEPENDS unit)
+  add_executable(inmemorybenchmark src/inmemorybenchmark.cpp)
+  target_link_libraries(inmemorybenchmark FastPFOR)
 
+  add_executable(unit src/unit.cpp)
+  target_link_libraries(unit FastPFOR)
+  add_custom_target(check unit DEPENDS unit)
 
-add_executable(FastPFOR_unittest
+  add_executable(FastPFOR_unittest
     unittest/test_composite.cpp
     unittest/test_driver.cpp
     unittest/test_fastpfor.cpp
     unittest/test_variablebyte.cpp)
-target_link_libraries(FastPFOR_unittest gtest FastPFOR)
-enable_testing()
-add_test("unit" unit)
-add_test("FastPFOR_unittest" FastPFOR_unittest)
-
+  target_link_libraries(FastPFOR_unittest gtest FastPFOR)
+  enable_testing()
+  add_test("FastPFOR_unittest" FastPFOR_unittest)
+endif()
 
 include(GNUInstallDirs)
 install(TARGETS FastPFOR


### PR DESCRIPTION
googletest is not necessary dependency  when we try to include this library.
For some areas with poor network condition, it's a burden to download googletest.
So I try to add WITH_TEST option (default ON with backward compatibility) to make it more convenient to use FastPFor.