### PR TITLE
Fix unused parameter warning in ByteAlignedPacking::decodeArray

### DIFF
--- a/headers/blockpacking.h
+++ b/headers/blockpacking.h
@@ -286,6 +286,7 @@ public:
 
   const uint32_t *decodeArray(const uint32_t *in, const size_t length,
                               uint32_t *out, size_t &nvalue) {
+    (void)length;
     const uint32_t actuallength = *in++;
     const uint8_t *inbyte = reinterpret_cast<const uint8_t *>(in);
     const uint32_t *const initout(out);


### PR DESCRIPTION
fixes the following warning:
```
c:\FastPFor\headers\blockpacking.h(287,64): warning : unused parameter 'length' [-Wunused-parameter]
  287 |   const uint32_t *decodeArray(const uint32_t *in, const size_t length,
```